### PR TITLE
Restrict storage find by base directory

### DIFF
--- a/graphrag/index/input/util.py
+++ b/graphrag/index/input/util.py
@@ -27,6 +27,7 @@ async def load_files(
     files = list(
         storage.find(
             re.compile(config.file_pattern),
+            base_dir=config.storage.base_dir,
             progress=progress,
             file_filter=config.file_filter,
         )

--- a/tests/integration/storage/test_blob_pipeline_storage.py
+++ b/tests/integration/storage/test_blob_pipeline_storage.py
@@ -63,6 +63,24 @@ async def test_dotprefix():
         storage._delete_container()  # noqa: SLF001
 
 
+async def test_find_respects_base_dir():
+    storage = BlobPipelineStorage(
+        connection_string=WELL_KNOWN_BLOB_STORAGE_KEY,
+        container_name="testbasedir",
+    )
+    try:
+        await storage.set("input/christmas.txt", "Merry Christmas!", encoding="utf-8")
+        await storage.set("inputfile/easter.txt", "Happy Easter!", encoding="utf-8")
+
+        items = list(
+            storage.find(base_dir="input", file_pattern=re.compile(r".*\.txt$"))
+        )
+        items = [item[0] for item in items]
+        assert items == ["input/christmas.txt"]
+    finally:
+        storage._delete_container()  # noqa: SLF001
+
+
 async def test_get_creation_date():
     storage = BlobPipelineStorage(
         connection_string=WELL_KNOWN_BLOB_STORAGE_KEY,

--- a/tests/integration/storage/test_file_pipeline_storage.py
+++ b/tests/integration/storage/test_file_pipeline_storage.py
@@ -36,6 +36,25 @@ async def test_find():
     assert output is None
 
 
+async def test_find_respects_base_dir(tmp_path):
+    storage = FilePipelineStorage(root_dir=str(tmp_path))
+
+    base_dir = "input"
+    (tmp_path / base_dir).mkdir()
+    (tmp_path / base_dir / "a.txt").write_text("A")
+    (tmp_path / f"{base_dir}file").mkdir()
+    (tmp_path / f"{base_dir}file" / "b.txt").write_text("B")
+
+    items = list(
+        storage.find(
+            base_dir=base_dir,
+            file_pattern=re.compile(r".*\.txt$"),
+        )
+    )
+    items = [item[0] for item in items]
+    assert items == [f"{base_dir}/a.txt"]
+
+
 async def test_get_creation_date():
     storage = FilePipelineStorage()
 


### PR DESCRIPTION
## Summary
- pass `base_dir` to storage.find when loading input files
- scope BlobPipelineStorage listing to the requested directory
- add tests ensuring search is limited to the base dir for blob and file storage

## Testing
- `pytest tests/integration/storage -q` *(fails: async functions not supported / connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_686abea50a488331b7e7a9cd228a5681