### PR TITLE
Add emulator skip helper to integration tests

### DIFF
--- a/tests/integration/storage/conftest.py
+++ b/tests/integration/storage/conftest.py
@@ -1,0 +1,29 @@
+import socket
+import pytest
+
+
+def _check_connection(host: str, port: int) -> bool:
+    """Return True if connection succeeds."""
+    try:
+        with socket.create_connection((host, port), timeout=1):
+            return True
+    except OSError:
+        return False
+
+
+def require_blob_emulator() -> None:
+    """Skip tests if the blob emulator is unreachable."""
+    if not _check_connection("127.0.0.1", 10000):
+        pytest.skip(
+            "Blob Storage emulator not running on 127.0.0.1:10000",
+            allow_module_level=True,
+        )
+
+
+def require_cosmos_emulator() -> None:
+    """Skip tests if the Cosmos DB emulator is unreachable."""
+    if not _check_connection("127.0.0.1", 8081):
+        pytest.skip(
+            "CosmosDB emulator not running on 127.0.0.1:8081",
+            allow_module_level=True,
+        )

--- a/tests/integration/storage/test_blob_pipeline_storage.py
+++ b/tests/integration/storage/test_blob_pipeline_storage.py
@@ -5,6 +5,10 @@
 import re
 from datetime import datetime
 
+from tests.integration.storage.conftest import require_blob_emulator
+
+require_blob_emulator()
+
 from graphrag.storage.blob_pipeline_storage import BlobPipelineStorage
 
 # cspell:disable-next-line well-known-key

--- a/tests/integration/storage/test_cosmosdb_storage.py
+++ b/tests/integration/storage/test_cosmosdb_storage.py
@@ -4,8 +4,9 @@
 
 import json
 import re
-import sys
 from datetime import datetime
+
+from tests.integration.storage.conftest import require_cosmos_emulator
 
 import pytest
 
@@ -14,11 +15,7 @@ from graphrag.storage.cosmosdb_pipeline_storage import CosmosDBPipelineStorage
 # cspell:disable-next-line well-known-key
 WELL_KNOWN_COSMOS_CONNECTION_STRING = "AccountEndpoint=https://127.0.0.1:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=="
 
-# the cosmosdb emulator is only available on windows runners at this time
-if not sys.platform.startswith("win"):
-    pytest.skip(
-        "encountered windows-only tests -- will skip for now", allow_module_level=True
-    )
+require_cosmos_emulator()
 
 
 async def test_find():

--- a/tests/integration/storage/test_factory.py
+++ b/tests/integration/storage/test_factory.py
@@ -5,9 +5,12 @@
 These tests will test the StorageFactory class and the creation of each storage type that is natively supported.
 """
 
-import sys
-
 import pytest
+
+from tests.integration.storage.conftest import (
+    require_blob_emulator,
+    require_cosmos_emulator,
+)
 
 from graphrag.config.enums import StorageType
 from graphrag.storage.blob_pipeline_storage import BlobPipelineStorage
@@ -23,6 +26,7 @@ WELL_KNOWN_COSMOS_CONNECTION_STRING = "AccountEndpoint=https://127.0.0.1:8081/;A
 
 
 def test_create_blob_storage():
+    require_blob_emulator()
     kwargs = {
         "type": "blob",
         "connection_string": WELL_KNOWN_BLOB_STORAGE_KEY,
@@ -33,11 +37,8 @@ def test_create_blob_storage():
     assert isinstance(storage, BlobPipelineStorage)
 
 
-@pytest.mark.skipif(
-    not sys.platform.startswith("win"),
-    reason="cosmosdb emulator is only available on windows runners at this time",
-)
 def test_create_cosmosdb_storage():
+    require_cosmos_emulator()
     kwargs = {
         "type": "cosmosdb",
         "connection_string": WELL_KNOWN_COSMOS_CONNECTION_STRING,

--- a/tests/integration/vector_stores/test_cosmosdb.py
+++ b/tests/integration/vector_stores/test_cosmosdb.py
@@ -3,10 +3,10 @@
 
 """Integration tests for CosmosDB vector store implementation."""
 
-import sys
-
 import numpy as np
 import pytest
+
+from tests.integration.storage.conftest import require_cosmos_emulator
 
 from graphrag.vector_stores.base import VectorStoreDocument
 from graphrag.vector_stores.cosmosdb import CosmosDBVectorStore
@@ -14,11 +14,7 @@ from graphrag.vector_stores.cosmosdb import CosmosDBVectorStore
 # cspell:disable-next-line well-known-key
 WELL_KNOWN_COSMOS_CONNECTION_STRING = "AccountEndpoint=https://127.0.0.1:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=="
 
-# the cosmosdb emulator is only available on windows runners at this time
-if not sys.platform.startswith("win"):
-    pytest.skip(
-        "encountered windows-only tests -- will skip for now", allow_module_level=True
-    )
+require_cosmos_emulator()
 
 
 def test_vector_store_operations():


### PR DESCRIPTION
## Summary
- skip storage and vector store tests when blob or cosmos db emulators aren't reachable
- add `require_blob_emulator` and `require_cosmos_emulator` helpers
- apply helpers to blob storage, cosmosdb storage, factory, and vector store tests

## Testing
- `poetry run pytest tests/integration/storage/test_blob_pipeline_storage.py -vv`
- `poetry run pytest tests/integration/storage/test_cosmosdb_storage.py -vv`
- `poetry run pytest tests/integration/storage/test_factory.py::test_create_cosmosdb_storage -vv`
- `poetry run pytest tests/integration/vector_stores/test_cosmosdb.py -vv`


------
https://chatgpt.com/codex/tasks/task_b_686ede7c1b3483318dc49b7e3fc57398