### PR TITLE
Fix path string conversion in file pipeline storage test

### DIFF
--- a/tests/integration/storage/test_file_pipeline_storage.py
+++ b/tests/integration/storage/test_file_pipeline_storage.py
@@ -24,7 +24,10 @@ async def test_find():
             file_filter=None,
         )
     )
-    assert items == [(str(Path("tests/fixtures/text/input/dulce.txt")), {})]
+    assert items == [(
+        Path("tests/fixtures/text/input/dulce.txt").as_posix(),
+        {},
+    )]
     output = await storage.get("tests/fixtures/text/input/dulce.txt")
     assert len(output) > 0
 


### PR DESCRIPTION
## Summary
- use `Path.as_posix()` in `test_find`

## Testing
- `pytest tests/integration/storage/test_file_pipeline_storage.py::test_find -q`

------
https://chatgpt.com/codex/tasks/task_b_687017fc179c8331b300640f29f42e84