### PR TITLE
Add Cosmos DB emulator helper

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -76,6 +76,18 @@ Some unit and smoke tests use Azurite to emulate Azure resources. This can be st
 
 or by simply running `azurite` in the terminal if already installed globally. See the [Azurite documentation](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite) for more information about how to install and use Azurite.
 
+# Cosmos DB Emulator
+
+Integration tests that use the `CosmosDBVectorStore` require the Azure Cosmos DB
+Emulator. You can start the emulator using Docker with the helper script:
+
+```sh
+./scripts/start-cosmos-emulator.sh
+```
+
+This runs the emulator with ports `8081` and `10250-10255` exposed and data
+persistence enabled.
+
 # Lifecycle Scripts
 
 Our Python package utilizes Poetry to manage dependencies and [poethepoet](https://pypi.org/project/poethepoet/) to manage custom build scripts.

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -38,6 +38,16 @@ Some unit and smoke tests use Azurite to emulate Azure resources. This can be st
 
 or by simply running `azurite` in the terminal if already installed globally. See the [Azurite documentation](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite) for more information about how to install and use Azurite.
 
+# Cosmos DB Emulator
+
+Integration tests that use the `CosmosDBVectorStore` require the Azure Cosmos DB Emulator. Start it with:
+
+```sh
+./scripts/start-cosmos-emulator.sh
+```
+
+This launches the emulator with ports `8081` and `10250-10255` exposed and with data persistence enabled.
+
 # Lifecycle Scripts
 
 Our Python package utilizes Poetry to manage dependencies and [poethepoet](https://pypi.org/project/poethepoet/) to manage build scripts.

--- a/scripts/start-cosmos-emulator.sh
+++ b/scripts/start-cosmos-emulator.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Start the Azure Cosmos DB Emulator using Docker
+
+docker run \
+  --name cosmosdb-emulator \
+  --privileged \
+  -p 8081:8081 \
+  -p 10250-10255:10250-10255 \
+  -e AZURE_COSMOS_EMULATOR_PARTITION_COUNT=10 \
+  -e AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE=true \
+  -e AZURE_COSMOS_EMULATOR_IP_ADDRESS_OVERRIDE=127.0.0.1 \
+  --cpus=2 \
+  --memory=3g \
+  mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator

--- a/tests/integration/storage/conftest.py
+++ b/tests/integration/storage/conftest.py
@@ -1,4 +1,8 @@
+# Copyright (c) 2024 Microsoft Corporation.
+# Licensed under the MIT License
+
 import socket
+
 import pytest
 
 

--- a/tests/integration/storage/test_blob_pipeline_storage.py
+++ b/tests/integration/storage/test_blob_pipeline_storage.py
@@ -5,11 +5,10 @@
 import re
 from datetime import datetime
 
+from graphrag.storage.blob_pipeline_storage import BlobPipelineStorage
 from tests.integration.storage.conftest import require_blob_emulator
 
 require_blob_emulator()
-
-from graphrag.storage.blob_pipeline_storage import BlobPipelineStorage
 
 # cspell:disable-next-line well-known-key
 WELL_KNOWN_BLOB_STORAGE_KEY = "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"

--- a/tests/integration/storage/test_cosmosdb_storage.py
+++ b/tests/integration/storage/test_cosmosdb_storage.py
@@ -6,11 +6,8 @@ import json
 import re
 from datetime import datetime
 
-from tests.integration.storage.conftest import require_cosmos_emulator
-
-import pytest
-
 from graphrag.storage.cosmosdb_pipeline_storage import CosmosDBPipelineStorage
+from tests.integration.storage.conftest import require_cosmos_emulator
 
 # cspell:disable-next-line well-known-key
 WELL_KNOWN_COSMOS_CONNECTION_STRING = "AccountEndpoint=https://127.0.0.1:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=="

--- a/tests/integration/storage/test_factory.py
+++ b/tests/integration/storage/test_factory.py
@@ -7,17 +7,16 @@ These tests will test the StorageFactory class and the creation of each storage 
 
 import pytest
 
-from tests.integration.storage.conftest import (
-    require_blob_emulator,
-    require_cosmos_emulator,
-)
-
 from graphrag.config.enums import StorageType
 from graphrag.storage.blob_pipeline_storage import BlobPipelineStorage
 from graphrag.storage.cosmosdb_pipeline_storage import CosmosDBPipelineStorage
 from graphrag.storage.factory import StorageFactory
 from graphrag.storage.file_pipeline_storage import FilePipelineStorage
 from graphrag.storage.memory_pipeline_storage import MemoryPipelineStorage
+from tests.integration.storage.conftest import (
+    require_blob_emulator,
+    require_cosmos_emulator,
+)
 
 # cspell:disable-next-line well-known-key
 WELL_KNOWN_BLOB_STORAGE_KEY = "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"

--- a/tests/integration/storage/test_file_pipeline_storage.py
+++ b/tests/integration/storage/test_file_pipeline_storage.py
@@ -24,10 +24,12 @@ async def test_find():
             file_filter=None,
         )
     )
-    assert items == [(
-        Path("tests/fixtures/text/input/dulce.txt").as_posix(),
-        {},
-    )]
+    assert items == [
+        (
+            Path("tests/fixtures/text/input/dulce.txt").as_posix(),
+            {},
+        )
+    ]
     output = await storage.get("tests/fixtures/text/input/dulce.txt")
     assert len(output) > 0
 
@@ -39,7 +41,7 @@ async def test_find():
     assert output is None
 
 
-async def test_find_respects_base_dir(tmp_path):
+def test_find_respects_base_dir(tmp_path):
     storage = FilePipelineStorage(root_dir=str(tmp_path))
 
     base_dir = "input"

--- a/tests/integration/vector_stores/test_cosmosdb.py
+++ b/tests/integration/vector_stores/test_cosmosdb.py
@@ -6,10 +6,9 @@
 import numpy as np
 import pytest
 
-from tests.integration.storage.conftest import require_cosmos_emulator
-
 from graphrag.vector_stores.base import VectorStoreDocument
 from graphrag.vector_stores.cosmosdb import CosmosDBVectorStore
+from tests.integration.storage.conftest import require_cosmos_emulator
 
 # cspell:disable-next-line well-known-key
 WELL_KNOWN_COSMOS_CONNECTION_STRING = "AccountEndpoint=https://127.0.0.1:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=="


### PR DESCRIPTION
## Summary
- add a helper script to start the Cosmos DB emulator
- document how to use the script in developer docs
- clean up integration tests for ruff compliance

## Testing
- `poetry run poe check`
- `poetry run poe test_unit` *(fails: test_sort_context, text_splitting tests)*

------
https://chatgpt.com/codex/tasks/task_b_68716480f6608331ae11d6e9bd62adcc