### PR TITLE
Fix blob storage dot prefix and smoke test CLI

### DIFF
--- a/.semversioner/next-release/patch-20250717203250636399.json
+++ b/.semversioner/next-release/patch-20250717203250636399.json
@@ -1,0 +1,4 @@
+{
+  "type": "patch",
+  "description": "Fix blob storage prefix '.' handling and CLI invocation in smoke tests"
+}

--- a/graphrag/storage/blob_pipeline_storage.py
+++ b/graphrag/storage/blob_pipeline_storage.py
@@ -56,7 +56,10 @@ class BlobPipelineStorage(PipelineStorage):
         self._encoding = encoding
         self._container_name = container_name
         self._connection_string = connection_string
-        self._path_prefix = path_prefix or ""
+        sanitized_prefix = path_prefix or ""
+        if sanitized_prefix in {".", "./"}:
+            sanitized_prefix = ""
+        self._path_prefix = sanitized_prefix.strip("/")
         self._storage_account_blob_url = storage_account_blob_url
         self._storage_account_name = (
             storage_account_blob_url.split("//")[1].split(".")[0]

--- a/tests/smoke/test_fixtures.py
+++ b/tests/smoke/test_fixtures.py
@@ -6,6 +6,7 @@ import logging
 import os
 import shutil
 import subprocess
+import sys
 from collections.abc import Callable
 from functools import wraps
 from pathlib import Path
@@ -40,6 +41,17 @@ env_vars = {
     "GRAPHRAG_CHUNK_OVERLAP": "0",
     "AZURE_AI_SEARCH_URL_ENDPOINT": os.getenv("AZURE_AI_SEARCH_URL_ENDPOINT"),
     "AZURE_AI_SEARCH_API_KEY": os.getenv("AZURE_AI_SEARCH_API_KEY"),
+    "GRAPHRAG_LLM_TYPE": "openai_chat",
+    "GRAPHRAG_EMBEDDING_TYPE": "openai_embedding",
+    "GRAPHRAG_API_KEY": "test-key",
+    "GRAPHRAG_API_BASE": "https://example.com",
+    "GRAPHRAG_API_VERSION": "v1",
+    "GRAPHRAG_LLM_DEPLOYMENT_NAME": "test-llm",
+    "GRAPHRAG_LLM_MODEL": "gpt-4",
+    "GRAPHRAG_LLM_TPM": "1000",
+    "GRAPHRAG_LLM_RPM": "1000",
+    "GRAPHRAG_EMBEDDING_DEPLOYMENT_NAME": "test-embed",
+    "GRAPHRAG_EMBEDDING_MODEL": "text-embedding-ada-002",
 }
 env_vars = {k: v for k, v in env_vars.items() if v is not None}
 
@@ -143,9 +155,9 @@ class TestIndexer:
         input_file_type: str,
     ):
         command = [
-            "poetry",
-            "run",
-            "poe",
+            sys.executable,
+            "-m",
+            "graphrag",
             "index",
             "--verbose" if debug else None,
             "--root",


### PR DESCRIPTION
## Summary
- treat `.` path prefix as empty for blob storage
- run smoke tests using current Python executable
- inject default LLM environment variables for smoke tests
- add semversioner change file

## Testing
- `poetry run poe test` *(fails: tiktoken tries to download data and proxy blocks request)*

------
https://chatgpt.com/codex/tasks/task_b_68716be12a78833189f43acf26a4b43f