### PR TITLE
Add Hugging Face embedding provider

### DIFF
--- a/graphrag/config/enums.py
+++ b/graphrag/config/enums.py
@@ -80,6 +80,7 @@ class ModelType(str, Enum):
     # Embeddings
     OpenAIEmbedding = "openai_embedding"
     AzureOpenAIEmbedding = "azure_openai_embedding"
+    HuggingFaceEmbedding = "huggingface_embedding"
 
     # Chat Completion
     OpenAIChat = "openai_chat"

--- a/graphrag/language_model/factory.py
+++ b/graphrag/language_model/factory.py
@@ -14,6 +14,9 @@ from graphrag.language_model.providers.fnllm.models import (
     OpenAIChatFNLLM,
     OpenAIEmbeddingFNLLM,
 )
+from graphrag.language_model.providers.huggingface.models import (
+    HuggingFaceEmbeddingModel,
+)
 
 
 class ModelFactory:
@@ -111,4 +114,8 @@ ModelFactory.register_embedding(
 )
 ModelFactory.register_embedding(
     ModelType.OpenAIEmbedding, lambda **kwargs: OpenAIEmbeddingFNLLM(**kwargs)
+)
+ModelFactory.register_embedding(
+    ModelType.HuggingFaceEmbedding,
+    lambda **kwargs: HuggingFaceEmbeddingModel(**kwargs),
 )

--- a/graphrag/language_model/providers/huggingface/__init__.py
+++ b/graphrag/language_model/providers/huggingface/__init__.py
@@ -1,0 +1,1 @@
+"""Hugging Face model provider implementations."""

--- a/graphrag/language_model/providers/huggingface/models.py
+++ b/graphrag/language_model/providers/huggingface/models.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+"""Hugging Face embedding model provider."""
+
+from typing import TYPE_CHECKING, Any
+import asyncio
+
+try:
+    from sentence_transformers import SentenceTransformer
+except Exception:  # pragma: no cover - dependency is optional
+    SentenceTransformer = None  # type: ignore[assignment]
+
+if TYPE_CHECKING:  # pragma: no cover - used for type hints only
+    from graphrag.cache.pipeline_cache import PipelineCache
+    from graphrag.callbacks.workflow_callbacks import WorkflowCallbacks
+    from graphrag.config.models.language_model_config import LanguageModelConfig
+
+
+class HuggingFaceEmbeddingModel:
+    """Embedding model backed by a Hugging Face `SentenceTransformer`."""
+
+    model: SentenceTransformer
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        config: LanguageModelConfig,
+        callbacks: WorkflowCallbacks | None = None,
+        cache: PipelineCache | None = None,
+    ) -> None:
+        if SentenceTransformer is None:  # pragma: no cover - dependency is optional
+            raise ImportError(
+                "sentence-transformers is required to use HuggingFace embeddings"
+            )
+        model_name = config.model or "sentence-transformers/all-MiniLM-L6-v2"
+        self.model = SentenceTransformer(model_name, use_auth_token=config.api_key)
+        self.config = config
+
+    async def aembed_batch(self, text_list: list[str], **kwargs: Any) -> list[list[float]]:
+        loop = asyncio.get_running_loop()
+        embeddings = await loop.run_in_executor(
+            None,
+            lambda: self.model.encode(text_list, convert_to_numpy=True, **kwargs),
+        )
+        return embeddings.tolist()
+
+    async def aembed(self, text: str, **kwargs: Any) -> list[float]:
+        return (await self.aembed_batch([text], **kwargs))[0]
+
+    def embed_batch(self, text_list: list[str], **kwargs: Any) -> list[list[float]]:
+        embeddings = self.model.encode(text_list, convert_to_numpy=True, **kwargs)
+        return embeddings.tolist()
+
+    def embed(self, text: str, **kwargs: Any) -> list[float]:
+        return self.embed_batch([text], **kwargs)[0]

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -13,6 +13,7 @@ from graphrag.config.create_graphrag_config import create_graphrag_config
 from graphrag.config.enums import AuthType, ModelType
 from graphrag.config.load_config import load_config
 from tests.unit.config.utils import (
+    DEFAULT_CHAT_MODEL_CONFIG,
     DEFAULT_EMBEDDING_MODEL_CONFIG,
     DEFAULT_MODEL_CONFIG,
     FAKE_API_KEY,
@@ -181,3 +182,29 @@ def test_load_config_missing_env_vars() -> None:
     root_dir = (cwd / "fixtures" / "minimal_config_missing_env_var").resolve()
     with pytest.raises(KeyError):
         load_config(root_dir=root_dir)
+
+
+def test_huggingface_embedding_without_api_key() -> None:
+    model_config = {
+        defs.DEFAULT_CHAT_MODEL_ID: DEFAULT_CHAT_MODEL_CONFIG,
+        defs.DEFAULT_EMBEDDING_MODEL_ID: {
+            "type": ModelType.HuggingFaceEmbedding,
+            "model": "sentence-transformers/all-MiniLM-L6-v2",
+        },
+    }
+
+    create_graphrag_config({"models": model_config})
+
+
+def test_huggingface_embedding_disallows_azure_managed_identity() -> None:
+    model_config = {
+        defs.DEFAULT_CHAT_MODEL_ID: DEFAULT_CHAT_MODEL_CONFIG,
+        defs.DEFAULT_EMBEDDING_MODEL_ID: {
+            "type": ModelType.HuggingFaceEmbedding,
+            "auth_type": AuthType.AzureManagedIdentity,
+            "model": "all-MiniLM-L6-v2",
+        },
+    }
+
+    with pytest.raises(ValidationError):
+        create_graphrag_config({"models": model_config})


### PR DESCRIPTION
## Summary
- add `HuggingFaceEmbedding` to model types
- allow optional Hugging Face tokens and skip Azure checks during config validation
- implement and register a Hugging Face embedding provider backed by `sentence-transformers`
- cover Hugging Face config validation with tests

## Testing
- `pytest tests/unit/config/test_config.py -k huggingface_embedding_without_api_key`
- `pytest tests/unit/config/test_config.py -k huggingface_embedding_disallows_azure_managed_identity`
- `pytest` *(fails: 31 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_b_68b60172179c833193d2fabb785445e7