### PR TITLE
Add HuggingFace text embedding strategy

### DIFF
--- a/graphrag/config/enums.py
+++ b/graphrag/config/enums.py
@@ -80,6 +80,7 @@ class ModelType(str, Enum):
     # Embeddings
     OpenAIEmbedding = "openai_embedding"
     AzureOpenAIEmbedding = "azure_openai_embedding"
+    HuggingFaceEmbedding = "huggingface_embedding"
 
     # Chat Completion
     OpenAIChat = "openai_chat"

--- a/graphrag/config/models/text_embedding_config.py
+++ b/graphrag/config/models/text_embedding_config.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field
 
 from graphrag.config.defaults import graphrag_config_defaults
 from graphrag.config.models.language_model_config import LanguageModelConfig
+from graphrag.config.enums import ModelType
 
 
 class TextEmbeddingConfig(BaseModel):
@@ -43,8 +44,14 @@ class TextEmbeddingConfig(BaseModel):
             TextEmbedStrategyType,
         )
 
+        strategy_type = (
+            TextEmbedStrategyType.huggingface
+            if model_config.type == ModelType.HuggingFaceEmbedding
+            else TextEmbedStrategyType.openai
+        )
+
         return self.strategy or {
-            "type": TextEmbedStrategyType.openai,
+            "type": strategy_type,
             "llm": model_config.model_dump(),
             "num_threads": model_config.concurrent_requests,
             "batch_size": self.batch_size,

--- a/graphrag/index/operations/embed_text/embed_text.py
+++ b/graphrag/index/operations/embed_text/embed_text.py
@@ -28,6 +28,7 @@ class TextEmbedStrategyType(str, Enum):
     """TextEmbedStrategyType class definition."""
 
     openai = "openai"
+    huggingface = "huggingface"
     mock = "mock"
 
     def __repr__(self):
@@ -208,6 +209,12 @@ def load_strategy(strategy: TextEmbedStrategyType) -> TextEmbeddingStrategy:
             )
 
             return run_openai
+        case TextEmbedStrategyType.huggingface:
+            from graphrag.index.operations.embed_text.strategies.huggingface import (
+                run as run_huggingface,
+            )
+
+            return run_huggingface
         case TextEmbedStrategyType.mock:
             from graphrag.index.operations.embed_text.strategies.mock import (
                 run as run_mock,

--- a/graphrag/index/operations/embed_text/strategies/huggingface.py
+++ b/graphrag/index/operations/embed_text/strategies/huggingface.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2024 Microsoft Corporation.
+# Licensed under the MIT License
+
+"""Text embedding strategy using HuggingFace sentence-transformers."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import numpy as np
+from sentence_transformers import SentenceTransformer
+
+from graphrag.cache.pipeline_cache import PipelineCache
+from graphrag.callbacks.workflow_callbacks import WorkflowCallbacks
+from graphrag.index.operations.embed_text.strategies.typing import TextEmbeddingResult
+from graphrag.logger.progress import progress_ticker
+
+
+async def run(
+    input: list[str],
+    callbacks: WorkflowCallbacks,
+    cache: PipelineCache,
+    args: dict[str, Any],
+) -> TextEmbeddingResult:
+    """Embed text using a locally hosted HuggingFace model."""
+    if not input:
+        return TextEmbeddingResult(embeddings=None)
+
+    model_info = args.get("llm", {})
+    model_name = model_info.get("model")
+    if model_name is None:
+        msg = "HuggingFace model name not provided"
+        raise ValueError(msg)
+
+    model = SentenceTransformer(model_name)
+
+    embeddings = await asyncio.to_thread(
+        model.encode,
+        input,
+        show_progress_bar=False,
+        convert_to_numpy=True,
+    )
+
+    ticker = progress_ticker(callbacks.progress, len(input))
+    ticker(len(input))
+
+    if isinstance(embeddings, np.ndarray):
+        emb_list = embeddings.tolist()
+    else:
+        emb_list = [
+            e.tolist() if isinstance(e, np.ndarray) else list(e) for e in embeddings
+        ]
+
+    return TextEmbeddingResult(embeddings=emb_list)

--- a/tests/unit/config/test_text_embedding_config.py
+++ b/tests/unit/config/test_text_embedding_config.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+
+from graphrag.config.enums import ModelType
+from graphrag.config.models.text_embedding_config import TextEmbeddingConfig
+from graphrag.index.operations.embed_text.embed_text import TextEmbedStrategyType
+
+
+@dataclass
+class DummyModelConfig:
+    type: ModelType
+    concurrent_requests: int = 1
+
+    def model_dump(self) -> dict:
+        return {"type": self.type, "model": "dummy"}
+
+
+def test_resolved_strategy_huggingface():
+    model_config = DummyModelConfig(type=ModelType.HuggingFaceEmbedding)
+    config = TextEmbeddingConfig()
+    strategy = config.resolved_strategy(model_config)
+    assert strategy["type"] == TextEmbedStrategyType.huggingface


### PR DESCRIPTION
## Summary
- add SentenceTransformer-based HuggingFace embedding strategy
- support `huggingface` in text embedding strategy enum and loader
- choose HuggingFace strategy when model type is `HuggingFaceEmbedding`

## Testing
- `pytest tests/unit/config/test_text_embedding_config.py -q`
- `pytest tests/verbs/test_generate_text_embeddings.py::test_generate_text_embeddings -q` *(fails: ModuleNotFoundError: No module named 'graspologic')*


------
https://chatgpt.com/codex/tasks/task_b_68b60193b0f483319cee9bd963d4ffe4