### PR TITLE
docs: add Hugging Face embedding model example

### DIFF
--- a/docs/config/env_vars.md
+++ b/docs/config/env_vars.md
@@ -2,7 +2,7 @@
 
 As of version 1.3, GraphRAG no longer supports a full complement of pre-built environment variables. Instead, we support variable replacement within the [settings.yml file](yaml.md) so you can specify any environment variables you like.
 
-The only standard environment variable we expect, and include in the default settings.yml, is `GRAPHRAG_API_KEY`. If you are already using a number of the previous GRAPHRAG_* environment variables, you can insert them with template syntax into settings.yml and they will be adopted.
+The only standard environment variable we expect, and include in the default settings.yml, is `GRAPHRAG_API_KEY` for Azure OpenAI models such as `gpt-4o`. If you are using a Hugging Face embedding model, supply a `HUGGINGFACE_API_TOKEN` instead. If you are already using a number of the previous GRAPHRAG_* environment variables, you can insert them with template syntax into settings.yml and they will be adopted.
 
 > **The environment variables below are documented as an aid for migration, but they WILL NOT be read unless you use template syntax in your settings.yml.**
 
@@ -74,6 +74,7 @@ These settings control the text embedding model used by the pipeline. Any settin
 
 | Parameter                                               | Required ?               | Description                                                                                                                | Type    | Default                  |
 | ------------------------------------------------------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------- | ------- | ------------------------ |
+| `HUGGINGFACE_API_TOKEN`                                 | **For HuggingFace**      | The API token to use when calling Hugging Face embeddings.                                   | `str`   | `None`                   |
 | `GRAPHRAG_EMBEDDING_TYPE`                               | **For AOAI**             | The embedding client to use. Either `openai_embedding` or `azure_openai_embedding`                                         | `str`   | `openai_embedding`       |
 | `GRAPHRAG_EMBEDDING_DEPLOYMENT_NAME`                    | **For AOAI**             | The AOAI deployment name.                                                                                                  | `str`   | `None`                   |
 | `GRAPHRAG_EMBEDDING_API_KEY`                            | Yes (uses fallback)      | The API key to use for the embedding client. If not defined when using AOAI, managed identity will be used.                | `str`   | `None`                   |

--- a/docs/config/models.md
+++ b/docs/config/models.md
@@ -53,6 +53,27 @@ global_search:
   reduce_prompt: "prompts/global_search_reduce_system_prompt.txt"
   knowledge_prompt: "prompts/global_search_knowledge_system_prompt.txt"
 ```
+To use a Hugging Face embedding model alongside an Azure OpenAI chat model, define both in your configuration. Reference the embedding model via `embed_text.model_id` while keeping the Azure OpenAI model for `prompt_tune` and query workflows:
+
+```yaml
+models:
+  azure_chat_model:
+    api_key: ${GRAPHRAG_API_KEY}
+    type: openai_chat
+    model: gpt-4o
+  hf_embed_model:
+    api_key: ${HUGGINGFACE_API_TOKEN}
+    type: huggingface_embedding
+    model: sentence-transformers/all-MiniLM-L6-v2
+    # device: cuda  # optional
+embed_text:
+  model_id: hf_embed_model
+prompt_tune:
+  chat_model_id: azure_chat_model
+query:
+  chat_model_id: azure_chat_model
+```
+
 
 Another option would be to avoid using a language model at all for the graph extraction, instead using the `fast` [indexing method](../index/methods.md) that uses NLP for portions of the indexing phase in lieu of LLM APIs.
 


### PR DESCRIPTION
## Summary
- document HUGGINGFACE_API_TOKEN and HuggingFaceEmbedding config
- explain referencing Hugging Face embedding model alongside Azure OpenAI chat model

## Testing
- `pytest tests/unit` *(fails: ModuleNotFoundError: No module named 'azure.cosmos')*

------
https://chatgpt.com/codex/tasks/task_b_68b6019945bc833195aa258f733f680b