### PR TITLE
test: add huggingface embedding tests

### DIFF
--- a/tests/fixtures/huggingface/settings.yml
+++ b/tests/fixtures/huggingface/settings.yml
@@ -1,0 +1,14 @@
+models:
+  default_chat_model:
+    api_key: ${GRAPHRAG_API_KEY}
+    type: azure_openai_chat
+    api_base: https://example.openai.azure.com/
+    api_version: '2023-05-15'
+    deployment_name: gpt-4o
+    model: gpt-4o
+    model_supports_json: true
+  default_embedding_model:
+    api_key: ${GRAPHRAG_API_KEY}
+    type: huggingface_embedding
+    model: sentence-transformers/all-MiniLM-L6-v2
+    encoding_model: cl100k_base

--- a/tests/hf_provider.py
+++ b/tests/hf_provider.py
@@ -1,0 +1,35 @@
+import asyncio
+from sentence_transformers import SentenceTransformer
+from graphrag.config.models.language_model_config import LanguageModelConfig
+from graphrag.language_model.factory import ModelFactory
+
+
+class HuggingFaceEmbeddingModel:
+    """Embedding model wrapper around a Hugging Face SentenceTransformer."""
+
+    def __init__(self, *, name: str, config: LanguageModelConfig, **kwargs):
+        self.model = SentenceTransformer(config.model)
+        self.config = config
+
+    def embed_batch(self, text_list: list[str], **kwargs) -> list[list[float]]:
+        embeddings = self.model.encode(text_list, convert_to_numpy=True)
+        return [emb.tolist() for emb in embeddings]
+
+    def embed(self, text: str, **kwargs) -> list[float]:
+        return self.embed_batch([text])[0]
+
+    async def aembed_batch(self, text_list: list[str], **kwargs) -> list[list[float]]:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self.embed_batch, text_list)
+
+    async def aembed(self, text: str, **kwargs) -> list[float]:
+        result = await self.aembed_batch([text])
+        return result[0]
+
+
+def register_huggingface_embedding() -> None:
+    """Register the Hugging Face embedding provider with the ModelFactory."""
+    ModelFactory.register_embedding(
+        "huggingface_embedding",
+        lambda **kwargs: HuggingFaceEmbeddingModel(**kwargs),
+    )

--- a/tests/unit/config/test_huggingface_config.py
+++ b/tests/unit/config/test_huggingface_config.py
@@ -1,0 +1,25 @@
+import yaml
+
+import graphrag.config.defaults as defs
+from graphrag.config.create_graphrag_config import create_graphrag_config
+from graphrag.config.enums import ModelType
+from graphrag.language_model.factory import ModelFactory
+from tests.mock_provider import MockEmbeddingLLM
+
+
+def test_graph_rag_config_supports_hf_and_azure_chat():
+    ModelFactory.register_embedding(
+        "huggingface_embedding", lambda **kwargs: MockEmbeddingLLM()
+    )
+    with open("tests/fixtures/huggingface/settings.yml", "r", encoding="utf-8") as fh:
+        settings = yaml.safe_load(fh)
+
+    config = create_graphrag_config(settings)
+
+    chat_model = config.get_language_model_config(defs.DEFAULT_CHAT_MODEL_ID)
+    embed_model = config.get_language_model_config(defs.DEFAULT_EMBEDDING_MODEL_ID)
+
+    assert chat_model.type == ModelType.AzureOpenAIChat
+    assert chat_model.model == "gpt-4o"
+    assert embed_model.type == "huggingface_embedding"
+    assert embed_model.model == "sentence-transformers/all-MiniLM-L6-v2"

--- a/tests/unit/test_huggingface_embedding.py
+++ b/tests/unit/test_huggingface_embedding.py
@@ -1,0 +1,23 @@
+import pytest
+pytest.importorskip("sentence_transformers")
+
+from graphrag.config.models.language_model_config import LanguageModelConfig
+from graphrag.language_model.factory import ModelFactory
+
+from tests.hf_provider import register_huggingface_embedding
+
+
+@pytest.mark.asyncio
+async def test_huggingface_embedding_vector_shape():
+    register_huggingface_embedding()
+    config = LanguageModelConfig(
+        api_key="test",
+        type="huggingface_embedding",
+        model="sentence-transformers/all-MiniLM-L6-v2",
+        encoding_model="cl100k_base",
+    )
+    model = ModelFactory.create_embedding_model(
+        "huggingface_embedding", name="hf", config=config
+    )
+    vector = await model.aembed("GraphRAG integrates HF models")
+    assert len(vector) == model.model.get_sentence_embedding_dimension()

--- a/tests/verbs/test_generate_text_embeddings_hf.py
+++ b/tests/verbs/test_generate_text_embeddings_hf.py
@@ -1,0 +1,78 @@
+import pytest
+pytest.importorskip("sentence_transformers")
+
+import graphrag.config.defaults as defs
+from graphrag.config.create_graphrag_config import create_graphrag_config
+from graphrag.config.enums import ModelType
+from graphrag.config.embeddings import all_embeddings
+from graphrag.index.operations.embed_text.embed_text import TextEmbedStrategyType
+from graphrag.index.workflows.generate_text_embeddings import run_workflow
+from graphrag.utils.storage import load_table_from_storage
+
+from tests.hf_provider import register_huggingface_embedding
+from tests.verbs.util import FAKE_API_KEY, create_test_context
+
+
+@pytest.mark.asyncio
+async def test_generate_text_embeddings_with_huggingface():
+    register_huggingface_embedding()
+    context = await create_test_context(
+        storage=[
+            "documents",
+            "relationships",
+            "text_units",
+            "entities",
+            "community_reports",
+        ]
+    )
+
+    model_configs = {
+        defs.DEFAULT_CHAT_MODEL_ID: {
+            "api_key": FAKE_API_KEY,
+            "type": ModelType.AzureOpenAIChat.value,
+            "api_base": "https://example.openai.azure.com/",
+            "api_version": "2023-05-15",
+            "deployment_name": "gpt-4o",
+            "model": "gpt-4o",
+            "model_supports_json": True,
+        },
+        defs.DEFAULT_EMBEDDING_MODEL_ID: {
+            "api_key": FAKE_API_KEY,
+            "type": "huggingface_embedding",
+            "model": "sentence-transformers/all-MiniLM-L6-v2",
+            "encoding_model": "cl100k_base",
+        },
+    }
+
+    config = create_graphrag_config({"models": model_configs})
+
+    assert (
+        config.get_language_model_config(defs.DEFAULT_CHAT_MODEL_ID).model
+        == "gpt-4o"
+    )
+    assert (
+        config.get_language_model_config(defs.DEFAULT_EMBEDDING_MODEL_ID).model
+        == "sentence-transformers/all-MiniLM-L6-v2"
+    )
+
+    llm_settings = config.get_language_model_config(
+        config.embed_text.model_id
+    ).model_dump()
+    config.embed_text.strategy = {
+        "type": TextEmbedStrategyType.openai,
+        "llm": llm_settings,
+    }
+    config.embed_text.names = list(all_embeddings)
+    config.snapshots.embeddings = True
+
+    await run_workflow(config, context)
+
+    parquet_files = context.output_storage.keys()
+    for field in all_embeddings:
+        assert f"embeddings.{field}.parquet" in parquet_files
+
+    entity_desc = await load_table_from_storage(
+        "embeddings.entity.description", context.output_storage
+    )
+    first = entity_desc.iloc[0]["embedding"]
+    assert len(first) == 384


### PR DESCRIPTION
## Summary
- add Hugging Face embedding provider helper for tests
- add tests covering Hugging Face embeddings and config example

## Testing
- `pytest tests/unit/test_huggingface_embedding.py tests/verbs/test_generate_text_embeddings_hf.py tests/unit/config/test_huggingface_config.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68b6019e20448331a282f1ec374b56a0