### PR TITLE
fix: use HF token for HF embedding

### DIFF
--- a/tests/fixtures/huggingface/settings.yml
+++ b/tests/fixtures/huggingface/settings.yml
@@ -8,7 +8,7 @@ models:
     model: gpt-4o
     model_supports_json: true
   default_embedding_model:
-    api_key: ${GRAPHRAG_API_KEY}
+    api_key: ${HUGGINGFACE_API_TOKEN}
     type: huggingface_embedding
     model: sentence-transformers/all-MiniLM-L6-v2
     encoding_model: cl100k_base


### PR DESCRIPTION
## Summary
- use HUGGINGFACE_API_TOKEN for Hugging Face embedding model in test fixture

## Testing
- `pytest tests/unit/config/test_huggingface_config.py tests/unit/test_huggingface_embedding.py tests/verbs/test_generate_text_embeddings_hf.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68b60ba0abe48331b87df46293a4d0c9