### PR TITLE
Skip huggingface smoke test without sentence-transformers

### DIFF
--- a/tests/smoke/test_fixtures.py
+++ b/tests/smoke/test_fixtures.py
@@ -202,6 +202,8 @@ class TestIndexer:
         if workflow_config.get("skip"):
             pytest.skip(f"Skipping smoke test {input_path}")
         root = Path(input_path)
+        if root.name == "huggingface":
+            pytest.importorskip("sentence_transformers")
         dispose = asyncio.run(prepare_azurite_data(input_path, workflow_config["azure"])) \
             if workflow_config.get("azure") else None
         self.__run_indexer(root, input_file_type)


### PR DESCRIPTION
## Summary
- skip huggingface smoke fixture when sentence_transformers is missing

## Testing
- `pytest tests/smoke/test_fixtures.py::TestIndexer::test_fixture -k huggingface -vv -c /tmp/empty.ini`


------
https://chatgpt.com/codex/tasks/task_b_68b75029e7b883318456dd0e2025b2ef