### PR TITLE
Use HuggingFace embed strategy in fixture

### DIFF
--- a/tests/fixtures/huggingface/settings.yml
+++ b/tests/fixtures/huggingface/settings.yml
@@ -14,8 +14,8 @@ models:
     async_mode: threaded
   default_embedding_model:
     type: huggingface_embedding
-    api_key: fake-hf-key
-    model: sentence-transformers/all-MiniLM-L6-v2
+    api_key: &hf_api_key fake-hf-key
+    model: &hf_model sentence-transformers/all-MiniLM-L6-v2
     encoding_model: cl100k_base
     tokens_per_minute: null
     requests_per_minute: null
@@ -47,4 +47,6 @@ drift_search:
 
 embed_text:
   strategy:
-    type: "mock"
+    type: "huggingface"
+    model: *hf_model
+    api_key: *hf_api_key


### PR DESCRIPTION
## Summary
- switch tests HuggingFace fixture to use huggingface embed_text strategy
- reference embedding model and API key using YAML anchors

## Testing
- `pytest tests/unit/config/test_huggingface_config.py tests/unit/config/test_text_embedding_config.py tests/unit/test_huggingface_embedding.py tests/verbs/test_generate_text_embeddings_hf.py` *(fails: ValidationError in GraphRagConfig)*

------
https://chatgpt.com/codex/tasks/task_b_68b74dad2a7c8331b67de3b60c9e9300