### PR TITLE
Handle optional Hugging Face credentials and fix pyproject duplicate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,6 @@ networkx = "^3.4.2"
 pandas = "^2.2.3"
 pyarrow = ">=17.0.0"
 umap-learn = "^0.5.6"
-sentence-transformers = ">=5.1.0"
 
 # Configuration
 pyyaml = "^6.0.2"

--- a/tests/fixtures/huggingface/settings.yml
+++ b/tests/fixtures/huggingface/settings.yml
@@ -14,7 +14,7 @@ models:
     async_mode: threaded
   default_embedding_model:
     type: huggingface_embedding
-    api_key: &hf_api_key fake-hf-key
+    api_key: &hf_api_key null
     model: &hf_model sentence-transformers/all-MiniLM-L6-v2
     encoding_model: cl100k_base
     tokens_per_minute: null


### PR DESCRIPTION
## Summary
- remove duplicate `sentence-transformers` dependency in pyproject
- disable fake Hugging Face API key in smoke test settings so downloads don't send invalid credentials

## Testing
- `pytest tests/smoke/test_fixtures.py::TestIndexer::test_fixture -k huggingface -vv` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_b_68b755cdd8348331b6ca6d153e4e798e