### PR TITLE
feat: support remote hugging face embeddings

### DIFF
--- a/docs/config/models.md
+++ b/docs/config/models.md
@@ -65,6 +65,7 @@ models:
     api_key: ${HUGGINGFACE_API_TOKEN}
     type: huggingface_embedding
     model: sentence-transformers/all-MiniLM-L6-v2
+    api_base: https://your-endpoint.aws.endpoints.huggingface.cloud  # optional
     # device: cuda  # optional
 embed_text:
   model_id: hf_embed_model
@@ -73,6 +74,10 @@ prompt_tune:
 query:
   chat_model_id: azure_chat_model
 ```
+
+Provide the `api_base` if your embedding model is served through a Hugging Face
+Inference Endpoint. The token supplied via `api_key` will be sent as a Bearer
+token when calling the endpoint.
 
 
 Another option would be to avoid using a language model at all for the graph extraction, instead using the `fast` [indexing method](../index/methods.md) that uses NLP for portions of the indexing phase in lieu of LLM APIs.

--- a/graphrag/index/operations/embed_text/strategies/huggingface.py
+++ b/graphrag/index/operations/embed_text/strategies/huggingface.py
@@ -6,10 +6,16 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from typing import Any
 
 import numpy as np
-from sentence_transformers import SentenceTransformer
+import requests
+
+try:  # pragma: no cover - optional dependency
+    from sentence_transformers import SentenceTransformer
+except Exception:  # pragma: no cover - optional dependency
+    SentenceTransformer = None  # type: ignore[assignment]
 
 from graphrag.cache.pipeline_cache import PipelineCache
 from graphrag.callbacks.workflow_callbacks import WorkflowCallbacks
@@ -23,15 +29,50 @@ async def run(
     cache: PipelineCache,
     args: dict[str, Any],
 ) -> TextEmbeddingResult:
-    """Embed text using a locally hosted HuggingFace model."""
+    """Embed text using HuggingFace locally or via a remote endpoint."""
     if not input:
         return TextEmbeddingResult(embeddings=None)
 
     model_info = args.get("llm", {})
     model_name = model_info.get("model")
+    api_base = model_info.get("api_base")
+    api_key = model_info.get("api_key") or os.getenv("HUGGING_FACE_TOKEN_READ_KEY")
+
+    if api_base:
+        if not api_key:
+            msg = "HuggingFace API key not provided"
+            raise ValueError(msg)
+        try:
+            response = await asyncio.to_thread(
+                requests.post,
+                api_base,
+                headers={"Authorization": f"Bearer {api_key}"},
+                json={"inputs": input},
+                timeout=30,
+            )
+            response.raise_for_status()
+            data = response.json()
+        except requests.RequestException as e:  # pragma: no cover - network failures
+            callbacks.error("HuggingFace embedding request failed", e)
+            msg = "HuggingFace embedding request failed"
+            raise RuntimeError(msg) from e
+
+        ticker = progress_ticker(callbacks.progress, len(input))
+        ticker(len(input))
+
+        if isinstance(data, dict):
+            embeddings = data.get("embeddings")
+        else:
+            embeddings = data
+        return TextEmbeddingResult(embeddings=embeddings)
+
     if model_name is None:
         msg = "HuggingFace model name not provided"
         raise ValueError(msg)
+
+    if SentenceTransformer is None:  # pragma: no cover - optional dependency
+        msg = "sentence-transformers is required to use local HuggingFace embeddings"
+        raise ImportError(msg)
 
     model = SentenceTransformer(model_name)
 

--- a/tests/unit/test_huggingface_remote_endpoint.py
+++ b/tests/unit/test_huggingface_remote_endpoint.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2025 Microsoft Corporation.
+# Copyright (c) 2025 Microsoft Corporation.
+# Licensed under the MIT License
+
+"""Tests for the remote Hugging Face embedding strategy."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from graphrag.cache.pipeline_cache import PipelineCache
+from graphrag.callbacks.workflow_callbacks import WorkflowCallbacks
+from graphrag.index.operations.embed_text.strategies.huggingface import run
+
+
+@pytest.mark.asyncio
+async def test_remote_hf_embeddings_send_auth_and_parse():
+    cache = MagicMock(spec=PipelineCache)
+    callbacks = MagicMock(spec=WorkflowCallbacks)
+    callbacks.progress = MagicMock()
+
+    fake_response = MagicMock()
+    fake_response.json.return_value = [[0.1, 0.2]]
+    fake_response.raise_for_status.return_value = None
+
+    with patch(
+        "graphrag.index.operations.embed_text.strategies.huggingface.requests.post",
+        return_value=fake_response,
+    ) as mock_post:
+        result = await run(
+            ["hello"],
+            callbacks,
+            cache,
+            {
+                "llm": {
+                    "model": "unused",
+                    "api_base": "https://example.com",
+                    "api_key": "tok",
+                }
+            },
+        )
+
+    mock_post.assert_called_once()
+    headers = mock_post.call_args.kwargs["headers"]
+    assert headers["Authorization"] == "Bearer tok"
+    assert result.embeddings == [[0.1, 0.2]]
+
+
+@pytest.mark.asyncio
+async def test_remote_hf_embeddings_http_error():
+    cache = MagicMock(spec=PipelineCache)
+    callbacks = MagicMock(spec=WorkflowCallbacks)
+    callbacks.progress = MagicMock()
+
+    with (
+        patch(
+            "graphrag.index.operations.embed_text.strategies.huggingface.requests.post",
+            side_effect=requests.HTTPError("boom"),
+        ),
+        pytest.raises(RuntimeError),
+    ):
+        await run(
+            ["hi"],
+            callbacks,
+            cache,
+            {
+                "llm": {
+                    "model": "unused",
+                    "api_base": "https://example.com",
+                    "api_key": "tok",
+                }
+            },
+        )


### PR DESCRIPTION
## Summary
- add ability to call Hugging Face Inference Endpoints for text embeddings
- document api_base usage for Hugging Face models
- test remote endpoint authorization and error handling

## Testing
- `poetry run pytest tests/unit/test_huggingface_remote_endpoint.py`
- `poetry run pyright graphrag/index/operations/embed_text/strategies/huggingface.py tests/unit/test_huggingface_remote_endpoint.py` *(fails: Import "sentence_transformers" could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_b_68bb40f477d883318940375dc0eb34e8