### PR TITLE
Ensure Hugging Face embedding requests use JSON headers

### DIFF
--- a/graphrag/index/operations/embed_text/strategies/huggingface.py
+++ b/graphrag/index/operations/embed_text/strategies/huggingface.py
@@ -46,7 +46,11 @@ async def run(
             response = await asyncio.to_thread(
                 requests.post,
                 api_base,
-                headers={"Authorization": f"Bearer {api_key}"},
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "Accept": "application/json",
+                    "Content-Type": "application/json",
+                },
                 json={"inputs": input},
                 timeout=30,
             )

--- a/graphrag/language_model/providers/huggingface/models.py
+++ b/graphrag/language_model/providers/huggingface/models.py
@@ -56,9 +56,15 @@ class HuggingFaceEmbeddingModel:
     def embed_batch(self, text_list: list[str], **kwargs: Any) -> list[list[float]]:
         if self.api_base:
             try:
+                headers = {
+                    "Accept": "application/json",
+                    "Content-Type": "application/json",
+                }
+                if self.api_key:
+                    headers["Authorization"] = f"Bearer {self.api_key}"
                 response = requests.post(
                     self.api_base,
-                    headers={"Authorization": f"Bearer {self.api_key}"} if self.api_key else {},
+                    headers=headers,
                     json={"inputs": text_list},
                     timeout=30,
                 )

--- a/tests/unit/test_huggingface_remote_endpoint.py
+++ b/tests/unit/test_huggingface_remote_endpoint.py
@@ -44,6 +44,8 @@ async def test_remote_hf_embeddings_send_auth_and_parse():
     mock_post.assert_called_once()
     headers = mock_post.call_args.kwargs["headers"]
     assert headers["Authorization"] == "Bearer tok"
+    assert headers["Accept"] == "application/json"
+    assert headers["Content-Type"] == "application/json"
     assert result.embeddings == [[0.1, 0.2]]
 
 

--- a/tests/unit/test_huggingface_remote_model_factory.py
+++ b/tests/unit/test_huggingface_remote_model_factory.py
@@ -36,6 +36,8 @@ async def test_remote_hf_embedding_model_factory_send_auth_and_parse():
     mock_post.assert_called_once()
     headers = mock_post.call_args.kwargs["headers"]
     assert headers["Authorization"] == "Bearer tok"
+    assert headers["Accept"] == "application/json"
+    assert headers["Content-Type"] == "application/json"
     assert result == [[0.1, 0.2]]
 
 


### PR DESCRIPTION
## Summary
- add `Accept` and `Content-Type` headers to Hugging Face remote embedding requests
- update Hugging Face embedding model to send JSON headers with optional authorization
- expand Hugging Face remote embedding tests to verify JSON headers

## Testing
- `pytest tests/unit/test_huggingface_remote_endpoint.py tests/unit/test_huggingface_remote_model_factory.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68bd8a1460448331bd267c890c23838d