### PR TITLE
feat: surface HuggingFace request errors

### DIFF
--- a/graphrag/index/operations/embed_text/strategies/huggingface.py
+++ b/graphrag/index/operations/embed_text/strategies/huggingface.py
@@ -57,8 +57,10 @@ async def run(
             response.raise_for_status()
             data = response.json()
         except requests.RequestException as e:  # pragma: no cover - network failures
-            callbacks.error("HuggingFace embedding request failed", e)
-            msg = "HuggingFace embedding request failed"
+            status = getattr(e.response, "status_code", "unknown")
+            text = getattr(e.response, "text", "")
+            msg = f"HuggingFace embedding request failed: {status} {text}"
+            callbacks.error(msg, e)
             raise RuntimeError(msg) from e
 
         ticker = progress_ticker(callbacks.progress, len(input))


### PR DESCRIPTION
## Summary
- include status code and response text in HuggingFace embedding request failures

## Testing
- `ruff check graphrag/index/operations/embed_text/strategies/huggingface.py`
- `pytest` *(fails: 34 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_68bd8ca03b188331a577fe40053918bc