### PR TITLE
feat: add huggingface token fallback

### DIFF
--- a/graphrag/index/operations/embed_text/strategies/huggingface.py
+++ b/graphrag/index/operations/embed_text/strategies/huggingface.py
@@ -1,7 +1,11 @@
 # Copyright (c) 2024 Microsoft Corporation.
 # Licensed under the MIT License
 
-"""Text embedding strategy using HuggingFace sentence-transformers."""
+"""Text embedding strategy using HuggingFace sentence-transformers.
+
+Supports the ``HUGGING_FACE_TOKEN_READ_KEY`` and ``HUGGINGFACE_API_TOKEN``
+environment variables for authentication.
+"""
 
 from __future__ import annotations
 
@@ -36,7 +40,12 @@ async def run(
     model_info = args.get("llm", {})
     model_name = model_info.get("model")
     api_base = model_info.get("api_base")
-    api_key = model_info.get("api_key") or os.getenv("HUGGING_FACE_TOKEN_READ_KEY")
+    # API key is sourced from model info or supported environment variables
+    api_key = (
+        model_info.get("api_key")
+        or os.getenv("HUGGING_FACE_TOKEN_READ_KEY")
+        or os.getenv("HUGGINGFACE_API_TOKEN")
+    )
 
     if api_base:
         if not api_key:


### PR DESCRIPTION
## Summary
- allow HuggingFace embeddings to read API key from HUGGINGFACE_API_TOKEN
- mirror token fallback in HuggingFace model provider and document supported environment variables

## Testing
- `ruff format graphrag/index/operations/embed_text/strategies/huggingface.py graphrag/language_model/providers/huggingface/models.py`
- `ruff check graphrag/index/operations/embed_text/strategies/huggingface.py graphrag/language_model/providers/huggingface/models.py` *(fails: BLE001, TC001, ARG001, SIM108, D100, CPY001, E402, I001, TRY003, EM101, D102)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'azure.storage', pandas, yaml, devtools, nbformat, aiofiles, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68bd9142eb44833185851dee52d971a6