### PR TITLE
Add ChatGPT binder workflow helper scripts

### DIFF
--- a/scripts/chatgpt_binder_workflow/graph_records_to_neo4j.py
+++ b/scripts/chatgpt_binder_workflow/graph_records_to_neo4j.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Convert GraphRAG tables into Neo4j import CSVs."""
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+from pathlib import Path
+from typing import Iterable
+
+
+def load_csv(path: Path) -> list[dict[str, str]]:
+    if not path.exists():
+        return []
+    with path.open("r", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        return [dict(row) for row in reader]
+
+
+def norm(value: str) -> str:
+    return " ".join(value.strip().lower().split())
+
+
+def entity_key(name: str, entity_type: str) -> str:
+    return f"{norm(entity_type)}:{norm(name)}"
+
+
+def attrs_fingerprint(attrs: dict) -> str:
+    data = json.dumps(attrs, sort_keys=True, ensure_ascii=False)
+    return hashlib.sha1(data.encode("utf-8")).hexdigest()
+
+
+def write_csv(path: Path, rows: Iterable[dict[str, object]], headers: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=headers)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def build_nodes(entities: list[dict[str, str]]) -> tuple[list[dict[str, object]], dict[str, int]]:
+    node_rows: list[dict[str, object]] = []
+    index: dict[str, int] = {}
+    next_id = 1
+
+    for entity in entities:
+        name = entity.get("name", "")
+        entity_type = entity.get("type", "Unknown")
+        key = entity_key(name, entity_type)
+        if key in index:
+            continue
+        index[key] = next_id
+        node_rows.append(
+            {
+                "id": next_id,
+                "name": name,
+                "type": entity_type,
+                "key": key,
+                "description": entity.get("description", ""),
+            }
+        )
+        next_id += 1
+
+    return node_rows, index
+
+
+def build_relationships(
+    relationships: list[dict[str, str]],
+    node_index: dict[str, int],
+) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    seen = set()
+    for rel in relationships:
+        source_key = entity_key(rel.get("source", ""), rel.get("source_type", ""))
+        target_key = entity_key(rel.get("target", ""), rel.get("target_type", ""))
+
+        if source_key not in node_index or target_key not in node_index:
+            continue
+
+        attrs = {
+            "description": rel.get("description", ""),
+            "strength": rel.get("strength", ""),
+        }
+        fingerprint = (
+            node_index[source_key],
+            node_index[target_key],
+            rel.get("relationship_type", "RELATED"),
+            attrs_fingerprint(attrs),
+        )
+        if fingerprint in seen:
+            continue
+        seen.add(fingerprint)
+
+        rows.append(
+            {
+                "start_id": node_index[source_key],
+                "end_id": node_index[target_key],
+                "type": rel.get("relationship_type", "RELATED"),
+                "attrs_json": json.dumps(attrs, ensure_ascii=False),
+            }
+        )
+
+    return rows
+
+
+def build_claims(claims: list[dict[str, str]], node_index: dict[str, int]) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for claim in claims:
+        subject_key = entity_key(claim.get("subject", ""), claim.get("subject_type", ""))
+        object_key = entity_key(claim.get("object", ""), claim.get("object_type", ""))
+        if subject_key not in node_index or object_key not in node_index:
+            continue
+        rows.append(
+            {
+                "subject_id": node_index[subject_key],
+                "object_id": node_index[object_key],
+                "claim_category": claim.get("claim_category", ""),
+                "status": claim.get("status", ""),
+                "date": claim.get("date", ""),
+                "description": claim.get("description", ""),
+                "evidence": claim.get("evidence", ""),
+            }
+        )
+    return rows
+
+
+def create_cypher(out_dir: Path, nodes_csv: Path, rels_csv: Path, claims_csv: Path | None) -> None:
+    statements = [
+        "// Load nodes",
+        "USING PERIODIC COMMIT 500",
+        f"LOAD CSV WITH HEADERS FROM 'file:///{nodes_csv.name}' AS row",
+        "MERGE (n:Entity {id: toInteger(row.id)})",
+        "  SET n.name = row.name, n.type = row.type, n.key = row.key, n.description = row.description;",
+        "",
+        "// Load relationships",
+        "USING PERIODIC COMMIT 500",
+        f"LOAD CSV WITH HEADERS FROM 'file:///{rels_csv.name}' AS row",
+        "MATCH (a:Entity {id: toInteger(row.start_id)})",
+        "MATCH (b:Entity {id: toInteger(row.end_id)})",
+        "WITH a, b, row",
+        "CALL apoc.create.relationship(a, row.type, apoc.convert.fromJsonMap(row.attrs_json), b) YIELD rel",
+        "RETURN count(rel);",
+    ]
+
+    if claims_csv is not None:
+        statements.extend(
+            [
+                "",
+                "// Load claims",
+                "USING PERIODIC COMMIT 500",
+                f"LOAD CSV WITH HEADERS FROM 'file:///{claims_csv.name}' AS row",
+                "MATCH (s:Entity {id: toInteger(row.subject_id)})",
+                "MATCH (o:Entity {id: toInteger(row.object_id)})",
+                "MERGE (s)-[c:CLAIM {category: row.claim_category, status: row.status}]->(o)",
+                "SET c.date = row.date, c.description = row.description, c.evidence = row.evidence;",
+            ]
+        )
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "import.cypher").write_text("\n".join(statements) + "\n", encoding="utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--entities", required=True, help="Summarized entities CSV")
+    parser.add_argument("--relationships", required=True, help="Summarized relationships CSV")
+    parser.add_argument("--claims", help="Optional claims CSV")
+    parser.add_argument("--out", required=True, help="Output directory for Neo4j CSVs")
+    args = parser.parse_args()
+
+    entities = load_csv(Path(args.entities))
+    relationships = load_csv(Path(args.relationships))
+    claims = load_csv(Path(args.claims)) if args.claims else []
+
+    nodes, index = build_nodes(entities)
+
+    for rel in relationships:
+        rel.setdefault("source_type", "")
+        rel.setdefault("target_type", "")
+        rel.setdefault("relationship_type", rel.get("type", "RELATED").upper().replace(" ", "_"))
+
+    rel_rows = build_relationships(relationships, index)
+
+    if claims:
+        for claim in claims:
+            claim.setdefault("subject_type", "")
+            claim.setdefault("object_type", "")
+        claim_rows = build_claims(claims, index)
+    else:
+        claim_rows = []
+
+    out_dir = Path(args.out)
+    nodes_csv = out_dir / "nodes.csv"
+    rels_csv = out_dir / "relationships.csv"
+    claims_csv = out_dir / "claims.csv" if claim_rows else None
+
+    write_csv(nodes_csv, nodes, ["id", "name", "type", "key", "description"])
+    write_csv(rels_csv, rel_rows, ["start_id", "end_id", "type", "attrs_json"])
+    if claim_rows and claims_csv is not None:
+        write_csv(
+            claims_csv,
+            claim_rows,
+            [
+                "subject_id",
+                "object_id",
+                "claim_category",
+                "status",
+                "date",
+                "description",
+                "evidence",
+            ],
+        )
+
+    create_cypher(out_dir, nodes_csv, rels_csv, claims_csv)
+
+    print(
+        json.dumps(
+            {
+                "nodes": len(nodes),
+                "relationships": len(rel_rows),
+                "claims": len(claim_rows),
+            }
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/chatgpt_binder_workflow/graph_records_to_tables.py
+++ b/scripts/chatgpt_binder_workflow/graph_records_to_tables.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Convert GraphRAG tuple output into entity and relationship tables."""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+from pathlib import Path
+from typing import Iterable, Iterator, Sequence
+
+Record = dict[str, str]
+
+
+def parse_records(
+    text: str,
+    record_delimiter: str,
+    tuple_delimiter: str,
+    completion_delimiter: str,
+) -> Iterator[tuple[str, Sequence[str]]]:
+    """Yield (kind, fields) pairs from the raw tuple output."""
+
+    text = text.replace(completion_delimiter, "")
+    parts = text.split(record_delimiter)
+    pattern = re.compile(
+        r"^\(\"(entity|relationship|claim)\""
+        + re.escape(tuple_delimiter)
+        + r"(.+)\)$",
+        re.DOTALL,
+    )
+
+    for block in parts:
+        block = block.strip()
+        if not block:
+            continue
+        match = pattern.match(block)
+        if not match:
+            continue
+        kind = match.group(1)
+        payload = match.group(2)
+        fields = [field.strip() for field in payload.split(tuple_delimiter)]
+        yield kind, fields
+
+
+def accumulate_entities(records: Iterable[Sequence[str]]) -> list[Record]:
+    aggregated: dict[str, dict[str, object]] = {}
+    for fields in records:
+        if len(fields) < 3:
+            continue
+        name, typ, *descriptions = fields
+        key = name.strip().upper()
+        entry = aggregated.setdefault(
+            key,
+            {"name": name.strip(), "type": typ.strip(), "descriptions": []},
+        )
+        description = tuple_delim_join(descriptions)
+        if description:
+            entry["descriptions"].append(description)
+    rows: list[Record] = []
+    for entry in aggregated.values():
+        for description in entry["descriptions"]:
+            rows.append(
+                {
+                    "name": entry["name"],
+                    "type": entry["type"],
+                    "description": description,
+                }
+            )
+    return rows
+
+
+def accumulate_relationships(records: Iterable[Sequence[str]]) -> list[Record]:
+    rows: list[Record] = []
+    for fields in records:
+        if len(fields) < 3:
+            continue
+        source = fields[0].strip()
+        target = fields[1].strip()
+        description = fields[2].strip()
+        strength = fields[3].strip() if len(fields) > 3 else ""
+        rows.append(
+            {
+                "source": source,
+                "target": target,
+                "description": description,
+                "strength": strength,
+            }
+        )
+    return rows
+
+
+def accumulate_claims(records: Iterable[Sequence[str]]) -> list[Record]:
+    rows: list[Record] = []
+    headers = [
+        "subject",
+        "object",
+        "claim_category",
+        "status",
+        "date",
+        "description",
+        "evidence",
+    ]
+    for fields in records:
+        data = {header: "" for header in headers}
+        for idx, header in enumerate(headers):
+            if idx < len(fields):
+                data[header] = fields[idx].strip()
+        rows.append(data)
+    return rows
+
+
+def tuple_delim_join(parts: Sequence[str]) -> str:
+    parts = [part.strip() for part in parts if part.strip()]
+    return " ".join(parts)
+
+
+def write_csv(path: Path, rows: Iterable[Record], headers: Sequence[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=headers)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", required=True, help="Path to the raw tuple file")
+    parser.add_argument("--record-delim", required=True, help="Record delimiter")
+    parser.add_argument("--tuple-delim", required=True, help="Tuple delimiter")
+    parser.add_argument("--completion", required=True, help="Completion delimiter")
+    parser.add_argument(
+        "--out-dir",
+        required=True,
+        help="Directory where CSV tables should be written",
+    )
+    args = parser.parse_args()
+
+    text = Path(args.input).read_text(encoding="utf-8")
+    records = list(
+        parse_records(text, args.record_delim, args.tuple_delim, args.completion)
+    )
+
+    entities = [fields for kind, fields in records if kind == "entity"]
+    relationships = [fields for kind, fields in records if kind == "relationship"]
+    claims = [fields for kind, fields in records if kind == "claim"]
+
+    out_dir = Path(args.out_dir)
+    write_csv(out_dir / "entities_raw.csv", accumulate_entities(entities), ["name", "type", "description"])
+    write_csv(
+        out_dir / "relationships_raw.csv",
+        accumulate_relationships(relationships),
+        ["source", "target", "description", "strength"],
+    )
+
+    if claims:
+        write_csv(
+            out_dir / "claims_raw.csv",
+            accumulate_claims(claims),
+            [
+                "subject",
+                "object",
+                "claim_category",
+                "status",
+                "date",
+                "description",
+                "evidence",
+            ],
+        )
+
+    summary = {
+        "entities": len(entities),
+        "relationships": len(relationships),
+        "claims": len(claims),
+    }
+    Path(out_dir / "summary.json").write_text(
+        json.dumps(summary, indent=2),
+        encoding="utf-8",
+    )
+    print(json.dumps(summary))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/chatgpt_binder_workflow/pack_and_manifest.py
+++ b/scripts/chatgpt_binder_workflow/pack_and_manifest.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Pack a corpus into ~N MiB plain-text binders for ChatGPT UI ingestion."""
+from __future__ import annotations
+
+import argparse
+import csv
+import html
+import io
+import re
+from pathlib import Path
+from typing import Callable, Iterable
+
+TOKENS_PER_CHAR_HEURISTIC = 1 / 4.0  # ≈4 chars per token
+SEP = "\n" + ("-" * 80) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Token estimation
+# ---------------------------------------------------------------------------
+
+def estimate_tokens(text: str) -> int:
+    """Estimate tokens for text using tiktoken when available."""
+    try:
+        import tiktoken  # type: ignore
+
+        enc = tiktoken.get_encoding("cl100k_base")
+        return len(enc.encode(text))
+    except Exception:
+        approx_chars = len(re.sub(r"\s+", " ", text))
+        return int(approx_chars * TOKENS_PER_CHAR_HEURISTIC)
+
+
+# ---------------------------------------------------------------------------
+# File readers
+# ---------------------------------------------------------------------------
+
+def read_txt(path: Path) -> str:
+    for encoding in ("utf-8", "utf-16", "latin-1"):
+        try:
+            return path.read_text(encoding=encoding, errors="ignore")
+        except Exception:
+            continue
+    return path.read_bytes().decode("utf-8", errors="ignore")
+
+
+def read_md(path: Path) -> str:
+    return read_txt(path)
+
+
+def strip_html(raw: str) -> str:
+    raw = html.unescape(raw)
+    raw = re.sub(r"<script[\s\S]*?</script>", " ", raw, flags=re.I)
+    raw = re.sub(r"<style[\s\S]*?</style>", " ", raw, flags=re.I)
+    text = re.sub(r"<[^>]+>", " ", raw)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+def read_html(path: Path) -> str:
+    return strip_html(read_txt(path))
+
+
+def read_pdf(path: Path) -> str:
+    try:
+        from pdfminer.high_level import extract_text  # type: ignore
+
+        return extract_text(str(path)) or ""
+    except Exception:
+        try:
+            import PyPDF2  # type: ignore
+
+            text_parts: list[str] = []
+            with path.open("rb") as handle:
+                reader = PyPDF2.PdfReader(handle)
+                for page in reader.pages:
+                    text_parts.append(page.extract_text() or "")
+            return "\n".join(text_parts)
+        except Exception:
+            return ""
+
+
+def read_docx(path: Path) -> str:
+    try:
+        import docx  # type: ignore
+
+        document = docx.Document(str(path))
+        return "\n".join(para.text for para in document.paragraphs)
+    except Exception:
+        return ""
+
+
+READERS: dict[str, Callable[[Path], str]] = {
+    ".txt": read_txt,
+    ".md": read_md,
+    ".markdown": read_md,
+    ".html": read_html,
+    ".htm": read_html,
+    ".pdf": read_pdf,
+    ".docx": read_docx,
+}
+
+DEFAULT_EXTENSIONS = tuple(READERS)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def gather_files(root: Path, extensions: Iterable[str], min_bytes: int) -> list[Path]:
+    ext_set = {ext.lower() for ext in extensions}
+    files: list[Path] = []
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        if path.suffix.lower() not in ext_set:
+            continue
+        if path.stat().st_size < min_bytes:
+            continue
+        files.append(path)
+    files.sort()
+    return files
+
+
+def to_text(path: Path) -> str:
+    reader = READERS.get(path.suffix.lower())
+    if reader is None:
+        return ""
+    text = reader(path)
+    if not isinstance(text, str):
+        try:
+            text = text.decode("utf-8", errors="ignore")
+        except Exception:
+            text = ""
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Core logic
+# ---------------------------------------------------------------------------
+
+def pack_binders(args: argparse.Namespace) -> None:
+    src = Path(args.src).expanduser().resolve()
+    out_dir = Path(args.out).expanduser().resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    extensions = args.extensions or DEFAULT_EXTENSIONS
+    files = gather_files(src, extensions, args.min_file_bytes)
+
+    by_parent: dict[Path, list[Path]] = {}
+    for file_path in files:
+        by_parent.setdefault(file_path.parent, []).append(file_path)
+
+    manifest_rows: list[dict[str, object]] = []
+    binder_index = 1
+
+    def flush_buffer(buffer: io.StringIO, folder_files: list[Path], start: int, end: int) -> None:
+        nonlocal binder_index
+        content = buffer.getvalue()
+        if not content.strip():
+            return
+        binder_name = f"binder_{binder_index:05d}.txt"
+        binder_path = out_dir / binder_name
+        binder_path.write_text(content, encoding="utf-8")
+        approx_tokens = estimate_tokens(content)
+        manifest_rows.append(
+            {
+                "binder_path": str(binder_path),
+                "size_bytes": binder_path.stat().st_size,
+                "approx_tokens": approx_tokens,
+                "source_files": ";".join(str(p) for p in folder_files[start:end]),
+            }
+        )
+        binder_index += 1
+
+    for folder, folder_files in by_parent.items():
+        buffer = io.StringIO()
+        size_bytes = 0
+        start_idx = 0
+
+        for idx, file_path in enumerate(folder_files):
+            text = to_text(file_path)
+            if not text:
+                continue
+
+            rel_folder = (
+                folder.relative_to(src)
+                if src in folder.parents or folder == src
+                else folder
+            )
+            header = (
+                f"SOURCE_FILE: {file_path}\n"
+                f"RELATIVE_TO: {rel_folder}\n\n"
+            )
+            chunk = header + text.strip() + SEP
+            chunk_bytes = len(chunk.encode("utf-8"))
+
+            if size_bytes + chunk_bytes > args.binder_bytes and buffer.tell() > 0:
+                flush_buffer(buffer, folder_files, start_idx, idx)
+                buffer = io.StringIO()
+                size_bytes = 0
+                start_idx = idx
+
+            buffer.write(chunk)
+            size_bytes += chunk_bytes
+
+        flush_buffer(buffer, folder_files, start_idx, len(folder_files))
+
+    manifest_path = out_dir / "manifest.csv"
+    with manifest_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=["binder_path", "size_bytes", "approx_tokens", "source_files"],
+        )
+        writer.writeheader()
+        for row in manifest_rows:
+            writer.writerow(row)
+
+    print(f"Wrote {len(manifest_rows)} binders -> {manifest_path}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--src", required=True, help="Root folder of the corpus")
+    parser.add_argument(
+        "--out",
+        required=True,
+        help="Output folder for binder .txt files and manifest.csv",
+    )
+    parser.add_argument(
+        "--binder-bytes",
+        type=int,
+        default=9_500_000,
+        help="Target bytes per binder (default ≈9.5 MiB)",
+    )
+    parser.add_argument(
+        "--min-file-bytes",
+        type=int,
+        default=256,
+        help="Skip files smaller than this many bytes",
+    )
+    parser.add_argument(
+        "--extensions",
+        nargs="*",
+        default=list(DEFAULT_EXTENSIONS),
+        help="Extensions to include (default: common text formats)",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version="pack_and_manifest 1.0",
+    )
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    pack_binders(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a binder packing utility that converts mixed-format corpora into upload-ready text binders with a manifest
- provide a parser that converts chat tuple outputs into raw entity, relationship, and claim CSV tables
- supply a Neo4j export helper that deduplicates entities/relationships and emits import-ready CSV plus Cypher

## Testing
- python -m compileall scripts/chatgpt_binder_workflow


------
https://chatgpt.com/codex/tasks/task_b_68dadbed10c08331a014a926fe39ae3b