### PR TITLE
Add ChatGPT UI markdown table aggregation script

### DIFF
--- a/docs/chatgpt_ui_pipeline.md
+++ b/docs/chatgpt_ui_pipeline.md
@@ -1,0 +1,74 @@
+# ChatGPT UI Binder Pipeline
+
+This optional toolkit mirrors the GraphRAG indexing prompts while routing every
+LLM interaction through the ChatGPT UI.  It is useful when direct API access is
+restricted or when you prefer to drive the workflow manually.
+
+## Contents
+
+The scripts live in `scripts/chatgpt_ui/` and can be mixed with the standard
+`chatgpt_prepare_docs.py` preparation flow.
+
+| Script | Purpose |
+| --- | --- |
+| `pack_and_manifest.py` | Packs source documents into ~9 MiB binder text files and writes a `manifest.csv` listing binder sizes, token estimates, and provenance. |
+| `graph_records_to_tables.py` | Parses the tuple-formatted output of the graph extraction prompt into `entities_raw.csv` and `relationships_raw.csv`. |
+| `gather_tables.py` | Converts markdown tables copied from ChatGPT UI into `entities_summarized.csv`, `relationships_summarized.csv`, and optional `claims.csv`. |
+| `graph_records_to_neo4j.py` | Merges the curated CSV tables (and optional claim tuples) into Neo4j import CSVs plus a helper `import.cypher`. |
+
+## Typical workflow
+
+1. **Pack documents**
+   ```bash
+   python scripts/chatgpt_ui/pack_and_manifest.py \
+     --src /path/to/corpus \
+     --out /path/to/binders \
+     --binder-bytes 9500000
+   ```
+   Upload each binder to ChatGPT and run the repository prompt templates.
+
+2. **Convert tuple output**
+   ```bash
+   python scripts/chatgpt_ui/graph_records_to_tables.py \
+     --input binder_00001.graph.txt \
+     --record-delim $'\n---\n' \
+     --tuple-delim '|||' \
+     --completion '<END>' \
+     --out-dir ./binder_00001
+   ```
+
+3. **Summarise descriptions** (via ChatGPT UI) and gather the resulting tables.
+   Save each ChatGPT response (entities, relationships, optional claims) to a
+   plain-text file and run:
+
+   ```bash
+   python scripts/chatgpt_ui/gather_tables.py \
+     --input-dir ./chatgpt_tables \
+     --out-dir ./prepared_tables
+   ```
+
+   The script reads every `.txt` / `.md` file in `--input-dir`, detects
+   markdown-formatted tables, and writes the combined
+   `entities_summarized.csv`, `relationships_summarized.csv`, and (if present)
+   `claims.csv` into `--out-dir`.
+
+4. **Export to Neo4j**
+   ```bash
+   python scripts/chatgpt_ui/graph_records_to_neo4j.py \
+     --entities entities_summarized.csv \
+     --relationships relationships_summarized.csv \
+     --claims claims.csv \
+     --out neo4j_export
+   ```
+   Copy the resulting CSVs into Neo4j's `import/` directory and execute the
+   generated `import.cypher` script.
+
+## Notes
+
+* The scripts are pure-Python and rely only on the standard library, although
+  `pack_and_manifest.py` will opportunistically use `pdfminer.six`, `PyPDF2`, or
+  `python-docx` when installed.
+* Delimiters must match the ones used in the prompt templates (`|||`, `---`,
+  `<END>`, etc.).
+* The Neo4j exporter deduplicates nodes and relationships by normalised names and
+  types.  Empty fields are ignored gracefully.

--- a/scripts/chatgpt_ui/gather_tables.py
+++ b/scripts/chatgpt_ui/gather_tables.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Convert ChatGPT UI markdown tables into CSV files for GraphRAG."""
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+from pathlib import Path
+from typing import Iterable, Iterator
+
+
+def normalise_header(value: str) -> str:
+    cleaned = re.sub(r"[^a-z0-9]+", " ", value.lower()).strip()
+    return re.sub(r"\s+", " ", cleaned)
+
+
+def iter_table_blocks(text: str) -> Iterator[list[str]]:
+    lines = text.splitlines()
+    block: list[str] = []
+    for raw_line in lines:
+        line = raw_line.strip()
+        if line.startswith("```"):
+            # ignore code fences entirely
+            continue
+        is_table_line = line.startswith("|")
+        if is_table_line:
+            block.append(line)
+            continue
+        if block:
+            yield block
+            block = []
+    if block:
+        yield block
+
+
+def parse_markdown_table(block: list[str]) -> tuple[list[str], list[dict[str, str]]]:
+    if len(block) < 2:
+        raise ValueError("table block is too small")
+
+    cleaned = [line.strip().strip("|") for line in block if line.strip()]
+    if len(cleaned) < 2:
+        raise ValueError("table block has no content")
+
+    header_cells = [cell.strip() for cell in cleaned[0].split("|")]
+    rows: list[dict[str, str]] = []
+
+    for line in cleaned[1:]:
+        divider = line.replace("-", "").replace(":", "").strip()
+        if not divider:
+            # alignment row like --- or :---:
+            continue
+        cells = [cell.strip() for cell in line.split("|")]
+        if len(cells) < len(header_cells):
+            cells.extend([""] * (len(header_cells) - len(cells)))
+        row = {header_cells[i]: cells[i] for i in range(len(header_cells))}
+        rows.append(row)
+
+    return header_cells, rows
+
+
+def find_column(headers: list[str], *keywords: str) -> str | None:
+    for header in headers:
+        normalised = normalise_header(header)
+        for keyword in keywords:
+            if keyword in normalised.split():
+                return header
+            if keyword in normalised.replace(" ", ""):
+                return header
+    return None
+
+
+def is_entities_table(headers: list[str]) -> bool:
+    name = find_column(headers, "entity", "name")
+    typ = find_column(headers, "type")
+    summary = find_column(headers, "summary", "description")
+    return bool(name and typ and summary)
+
+
+def is_relationships_table(headers: list[str]) -> bool:
+    src = find_column(headers, "source", "subject", "from")
+    dst = find_column(headers, "target", "object", "to")
+    summary = find_column(headers, "summary", "description")
+    return bool(src and dst and summary)
+
+
+def is_claims_table(headers: list[str]) -> bool:
+    subj = find_column(headers, "subject")
+    obj = find_column(headers, "object")
+    category = find_column(headers, "category", "claimtype")
+    status = find_column(headers, "status")
+    description = find_column(headers, "description", "summary")
+    evidence = find_column(headers, "evidence", "quote", "source text")
+    return bool(subj and obj and category and status and description and evidence)
+
+
+def collect_tables(texts: Iterable[str]) -> tuple[list[dict[str, str]], list[dict[str, str]], list[dict[str, str]]]:
+    entities: list[dict[str, str]] = []
+    relationships: list[dict[str, str]] = []
+    claims: list[dict[str, str]] = []
+
+    for text in texts:
+        for block in iter_table_blocks(text):
+            try:
+                headers, rows = parse_markdown_table(block)
+            except ValueError:
+                continue
+            if not rows:
+                continue
+
+            if is_entities_table(headers):
+                name_col = find_column(headers, "entity", "name")
+                type_col = find_column(headers, "type")
+                summary_col = find_column(headers, "summary", "description")
+                for row in rows:
+                    name = row.get(name_col or "", "").strip()
+                    summary = row.get(summary_col or "", "").strip()
+                    if not name and not summary:
+                        continue
+                    entities.append(
+                        {
+                            "name": name,
+                            "type": row.get(type_col or "", "").strip(),
+                            "summary": summary,
+                        }
+                    )
+                continue
+
+            if is_relationships_table(headers):
+                source_col = find_column(headers, "source", "subject", "from")
+                target_col = find_column(headers, "target", "object", "to")
+                summary_col = find_column(headers, "summary", "description")
+                strength_col = find_column(headers, "strength", "weight", "confidence")
+                type_col = find_column(headers, "type", "predicate", "relationship")
+                for row in rows:
+                    source = row.get(source_col or "", "").strip()
+                    target = row.get(target_col or "", "").strip()
+                    if not source or not target:
+                        continue
+                    relationships.append(
+                        {
+                            "source": source,
+                            "target": target,
+                            "summary": row.get(summary_col or "", "").strip(),
+                            "strength": row.get(strength_col or "", "").strip(),
+                            "type": row.get(type_col or "", "").strip(),
+                        }
+                    )
+                continue
+
+            if is_claims_table(headers):
+                subject_col = find_column(headers, "subject")
+                object_col = find_column(headers, "object")
+                category_col = find_column(headers, "category", "claimtype")
+                status_col = find_column(headers, "status")
+                description_col = find_column(headers, "description", "summary")
+                evidence_col = find_column(headers, "evidence", "quote", "source text")
+                source_col = find_column(headers, "source", "provenance", "binder")
+                start_col = find_column(headers, "start", "date start")
+                end_col = find_column(headers, "end", "date end")
+                for row in rows:
+                    subject = row.get(subject_col or "", "").strip()
+                    obj = row.get(object_col or "", "").strip()
+                    if not subject or not obj:
+                        continue
+                    claims.append(
+                        {
+                            "subject": subject,
+                            "object": obj,
+                            "category": row.get(category_col or "", "").strip(),
+                            "status": row.get(status_col or "", "").strip(),
+                            "description": row.get(description_col or "", "").strip(),
+                            "evidence": row.get(evidence_col or "", "").strip(),
+                            "source_file": row.get(source_col or "", "").strip(),
+                            "start_date": row.get(start_col or "", "").strip(),
+                            "end_date": row.get(end_col or "", "").strip(),
+                        }
+                    )
+                continue
+
+    return entities, relationships, claims
+
+
+def write_csv(path: Path, fieldnames: list[str], rows: Iterable[dict[str, str]]) -> None:
+    with path.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({key: row.get(key, "") for key in fieldnames})
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input-dir", required=True, type=Path)
+    parser.add_argument("--out-dir", required=True, type=Path)
+    args = parser.parse_args()
+
+    texts: list[str] = []
+    for path in sorted(args.input_dir.glob("**/*")):
+        if path.is_dir():
+            continue
+        if path.suffix.lower() not in {".txt", ".md", ".markdown"}:
+            continue
+        texts.append(path.read_text(encoding="utf-8"))
+
+    entities, relationships, claims = collect_tables(texts)
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    if entities:
+        write_csv(args.out_dir / "entities_summarized.csv", ["name", "type", "summary"], entities)
+    if relationships:
+        write_csv(
+            args.out_dir / "relationships_summarized.csv",
+            ["source", "target", "summary", "strength", "type"],
+            relationships,
+        )
+    if claims:
+        write_csv(
+            args.out_dir / "claims.csv",
+            [
+                "subject",
+                "object",
+                "category",
+                "status",
+                "description",
+                "evidence",
+                "source_file",
+                "start_date",
+                "end_date",
+            ],
+            claims,
+        )
+
+
+if __name__ == "__main__":
+    main()
+

--- a/scripts/chatgpt_ui/graph_records_to_neo4j.py
+++ b/scripts/chatgpt_ui/graph_records_to_neo4j.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Convert ChatGPT UI extraction tables into Neo4j import CSVs."""
+from __future__ import annotations
+
+import argparse
+import csv
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable
+
+
+@dataclass
+class Node:
+    id: int
+    name: str
+    type: str
+    summary: str
+
+
+@dataclass
+class Relationship:
+    start_id: int
+    end_id: int
+    type: str
+    summary: str
+    strength: str
+
+
+@dataclass
+class Claim:
+    id: int
+    subject_id: int
+    object_id: int
+    category: str
+    status: str
+    description: str
+    evidence: str
+    source: str
+
+
+def norm(text: str) -> str:
+    return " ".join(text.strip().lower().split())
+
+
+def load_csv(path: Path) -> list[dict[str, str]]:
+    if not path.exists():
+        return []
+    with path.open("r", encoding="utf-8-sig", newline="") as fh:
+        reader = csv.DictReader(fh)
+        rows: list[dict[str, str]] = []
+        for row in reader:
+            cleaned: dict[str, str] = {}
+            for key, value in row.items():
+                clean_key = (key or "").strip()
+                clean_value = value.strip() if isinstance(value, str) else ""
+                cleaned[clean_key] = clean_value
+            rows.append(cleaned)
+        return rows
+
+
+def node_key(name: str, typ: str) -> str:
+    return f"{norm(typ)}::{norm(name)}"
+
+
+def upsert_node(
+    nodes: Dict[str, Node],
+    name: str,
+    typ: str,
+    summary: str,
+    next_id: int,
+) -> tuple[int, int]:
+    key = node_key(name, typ or "Unknown")
+    if key in nodes:
+        node = nodes[key]
+        if summary and summary not in node.summary:
+            parts = [node.summary, summary]
+            node.summary = "; ".join(part for part in parts if part)
+        return node.id, next_id
+    node = Node(id=next_id, name=name, type=typ or "Unknown", summary=summary)
+    nodes[key] = node
+    return node.id, next_id + 1
+
+
+def normalise_relationship_type(value: str) -> str:
+    if not value:
+        return "RELATED_TO"
+    return "_".join(part for part in value.upper().split()) or "RELATED_TO"
+
+
+def write_csv(path: Path, fieldnames: list[str], rows: Iterable[dict[str, str]]) -> None:
+    with path.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def build_graph(
+    entities_csv: Path,
+    relationships_csv: Path,
+    claims_csv: Path | None,
+    out_dir: Path,
+) -> None:
+    nodes: Dict[str, Node] = {}
+    relationships: list[Relationship] = []
+    claims: list[Claim] = []
+    next_node_id = 1
+    next_claim_id = 1
+
+    # Entities
+    for row in load_csv(entities_csv):
+        name = row.get("name", "").strip()
+        typ = row.get("type", "Unknown").strip()
+        summary = row.get("summary", "").strip() or row.get("description", "").strip()
+        if not name:
+            continue
+        _, next_node_id = upsert_node(nodes, name, typ, summary, next_node_id)
+
+    # Relationships
+    for row in load_csv(relationships_csv):
+        source = row.get("source", "").strip()
+        target = row.get("target", "").strip()
+        if not source or not target:
+            continue
+        summary = row.get("summary", "").strip() or row.get("description", "").strip()
+        strength = row.get("strength", "").strip() or row.get("weight", "").strip()
+        rel_type = (
+            row.get("type")
+            or row.get("relationship_type")
+            or row.get("predicate")
+            or "RELATED_TO"
+        )
+        source_type = row.get("source_type", "Unknown")
+        target_type = row.get("target_type", "Unknown")
+        source_summary = row.get("source_summary", "").strip()
+        target_summary = row.get("target_summary", "").strip()
+        source_id, next_node_id = upsert_node(
+            nodes, source, source_type, source_summary, next_node_id
+        )
+        target_id, next_node_id = upsert_node(
+            nodes, target, target_type, target_summary, next_node_id
+        )
+        relationships.append(
+            Relationship(
+                start_id=source_id,
+                end_id=target_id,
+                type=normalise_relationship_type(rel_type),
+                summary=summary,
+                strength=strength,
+            )
+        )
+
+    # Claims
+    if claims_csv:
+        for row in load_csv(claims_csv):
+            subject = row.get("subject", "").strip() or row.get("source", "").strip()
+            obj = row.get("object", "").strip() or row.get("target", "").strip()
+            if not subject or not obj:
+                continue
+            subject_type = row.get("subject_type", "Unknown")
+            object_type = row.get("object_type", "Unknown")
+            subject_summary = row.get("subject_summary", "").strip()
+            object_summary = row.get("object_summary", "").strip()
+            subject_id, next_node_id = upsert_node(
+                nodes, subject, subject_type, subject_summary, next_node_id
+            )
+            object_id, next_node_id = upsert_node(
+                nodes, obj, object_type, object_summary, next_node_id
+            )
+            claims.append(
+                Claim(
+                    id=next_claim_id,
+                    subject_id=subject_id,
+                    object_id=object_id,
+                    category=row.get("category", "").strip(),
+                    status=row.get("status", "").strip(),
+                    description=row.get("description", "").strip()
+                    or row.get("summary", "").strip(),
+                    evidence=row.get("evidence", "").strip()
+                    or row.get("quote", "").strip(),
+                    source=row.get("source_file", "").strip(),
+                )
+            )
+            next_claim_id += 1
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    node_rows = [
+        {
+            "id": str(node.id),
+            "name": node.name,
+            "type": node.type,
+            "summary": node.summary,
+        }
+        for node in sorted(nodes.values(), key=lambda n: n.id)
+    ]
+
+    rel_seen: set[tuple[int, int, str, str, str]] = set()
+    rel_rows: list[dict[str, str]] = []
+    for rel in relationships:
+        fingerprint = (
+            rel.start_id,
+            rel.end_id,
+            rel.type,
+            rel.summary,
+            rel.strength,
+        )
+        if fingerprint in rel_seen:
+            continue
+        rel_seen.add(fingerprint)
+        rel_rows.append(
+            {
+                "start_id": str(rel.start_id),
+                "end_id": str(rel.end_id),
+                "type": rel.type,
+                "summary": rel.summary,
+                "strength": rel.strength,
+            }
+        )
+
+    claim_rows = [
+        {
+            "id": str(claim.id),
+            "subject_id": str(claim.subject_id),
+            "object_id": str(claim.object_id),
+            "category": claim.category,
+            "status": claim.status,
+            "description": claim.description,
+            "evidence": claim.evidence,
+            "source": claim.source,
+        }
+        for claim in claims
+    ]
+
+    write_csv(out_dir / "nodes.csv", ["id", "name", "type", "summary"], node_rows)
+    write_csv(
+        out_dir / "relationships.csv",
+        ["start_id", "end_id", "type", "summary", "strength"],
+        rel_rows,
+    )
+    if claim_rows:
+        write_csv(
+            out_dir / "claims.csv",
+            [
+                "id",
+                "subject_id",
+                "object_id",
+                "category",
+                "status",
+                "description",
+                "evidence",
+                "source",
+            ],
+            claim_rows,
+        )
+
+    cypher = f"""
+// Load nodes
+USING PERIODIC COMMIT 500
+LOAD CSV WITH HEADERS FROM 'file:///{(out_dir / 'nodes.csv').name}' AS row
+MERGE (n:Entity {{id: toInteger(row.id)}})
+  SET n.name = row.name, n.type = row.type, n.summary = row.summary;
+
+// Load relationships
+USING PERIODIC COMMIT 500
+LOAD CSV WITH HEADERS FROM 'file:///{(out_dir / 'relationships.csv').name}' AS row
+MATCH (a:Entity {{id: toInteger(row.start_id)}})
+MATCH (b:Entity {{id: toInteger(row.end_id)}})
+CALL apoc.create.relationship(
+  a,
+  row.type,
+  {{summary: row.summary, strength: row.strength}},
+  b
+) YIELD rel
+RETURN count(rel);
+"""
+
+    if claim_rows:
+        cypher += f"""
+// Load claims
+USING PERIODIC COMMIT 500
+LOAD CSV WITH HEADERS FROM 'file:///{(out_dir / 'claims.csv').name}' AS row
+MATCH (a:Entity {{id: toInteger(row.subject_id)}})
+MATCH (b:Entity {{id: toInteger(row.object_id)}})
+MERGE (c:Claim {{id: toInteger(row.id)}})
+  SET c.category = row.category,
+      c.status = row.status,
+      c.description = row.description,
+      c.evidence = row.evidence,
+      c.source = row.source;
+MERGE (a)-[:ASSERTS]->(c)
+MERGE (c)-[:ABOUT]->(b);
+"""
+
+    (out_dir / "import.cypher").write_text(cypher.strip() + "\n", encoding="utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--entities", required=True, type=Path)
+    parser.add_argument("--relationships", required=True, type=Path)
+    parser.add_argument("--claims", type=Path)
+    parser.add_argument("--out", required=True, type=Path)
+    args = parser.parse_args()
+
+    build_graph(args.entities, args.relationships, args.claims, args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/chatgpt_ui/graph_records_to_tables.py
+++ b/scripts/chatgpt_ui/graph_records_to_tables.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Convert ChatGPT tuple records into CSV tables for GraphRAG."""
+from __future__ import annotations
+
+import argparse
+import csv
+from pathlib import Path
+from typing import Iterable
+
+
+def normalise(text: str) -> str:
+    return text.strip().strip('"').strip()
+
+
+def parse_records(
+    raw_text: str, record_delim: str, tuple_delim: str, completion: str
+) -> Iterable[tuple[str, list[str]]]:
+    cleaned = raw_text.replace(completion, "")
+    for block in cleaned.split(record_delim):
+        block = block.strip()
+        if not block:
+            continue
+        if block.startswith("(") and block.endswith(")"):
+            block = block[1:-1]
+        parts = [normalise(part) for part in block.split(tuple_delim)]
+        if not parts:
+            continue
+        kind = parts[0].lower()
+        yield kind, parts[1:]
+
+
+def write_entities(records: Iterable[list[str]], path: Path) -> None:
+    fieldnames = ["name", "type", "description"]
+    with path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fieldnames)
+        writer.writeheader()
+        for record in records:
+            if len(record) < 3:
+                continue
+            name, typ, *desc_parts = record
+            description = "|||".join(desc_parts).strip()
+            writer.writerow({"name": name, "type": typ, "description": description})
+
+
+def write_relationships(records: Iterable[list[str]], path: Path) -> None:
+    fieldnames = ["source", "target", "description", "strength"]
+    with path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fieldnames)
+        writer.writeheader()
+        for record in records:
+            if len(record) < 3:
+                continue
+            source = record[0]
+            target = record[1]
+            description = record[2]
+            strength = record[3] if len(record) > 3 else ""
+            writer.writerow(
+                {
+                    "source": source,
+                    "target": target,
+                    "description": description,
+                    "strength": strength,
+                }
+            )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, type=Path)
+    parser.add_argument("--record-delim", required=True)
+    parser.add_argument("--tuple-delim", required=True)
+    parser.add_argument("--completion", required=True)
+    parser.add_argument("--out-dir", required=True, type=Path)
+    args = parser.parse_args()
+
+    raw_text = args.input.read_text(encoding="utf-8")
+    entity_records: list[list[str]] = []
+    relationship_records: list[list[str]] = []
+
+    for kind, parts in parse_records(raw_text, args.record_delim, args.tuple_delim, args.completion):
+        if kind == "entity":
+            entity_records.append(parts)
+        elif kind == "relationship":
+            relationship_records.append(parts)
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    write_entities(entity_records, args.out_dir / "entities_raw.csv")
+    write_relationships(relationship_records, args.out_dir / "relationships_raw.csv")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/chatgpt_ui/pack_and_manifest.py
+++ b/scripts/chatgpt_ui/pack_and_manifest.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Pack a corpus into ~N MiB binder text files for ChatGPT UI ingestion.
+
+The script walks an input folder, converts supported documents into text, and
+writes binder text files in the output directory.  A ``manifest.csv`` file is
+also produced describing each binder along with its approximate token count and
+source files.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import html
+import io
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Iterable
+
+# Rough fallback conversion between characters and tokens.
+TOKENS_PER_CHAR_HEURISTIC = 1 / 4.0
+
+
+@dataclass
+class Args:
+    src: Path
+    out: Path
+    binder_bytes: int
+    min_file_bytes: int
+    extensions: list[str]
+
+
+def estimate_tokens(text: str) -> int:
+    """Estimate token count for ``text`` using tiktoken when available."""
+    try:
+        import tiktoken  # type: ignore
+
+        encoder = tiktoken.get_encoding("cl100k_base")
+        return len(encoder.encode(text))
+    except Exception:
+        collapsed = re.sub(r"\s+", " ", text)
+        return int(len(collapsed) * TOKENS_PER_CHAR_HEURISTIC)
+
+
+def read_txt(path: Path) -> str:
+    for encoding in ("utf-8", "utf-16", "latin-1"):
+        try:
+            return path.read_text(encoding=encoding, errors="ignore")
+        except Exception:
+            continue
+    return path.read_bytes().decode("utf-8", errors="ignore")
+
+
+def read_md(path: Path) -> str:
+    return read_txt(path)
+
+
+def strip_html(raw: str) -> str:
+    raw = html.unescape(raw)
+    raw = re.sub(r"<script[\s\S]*?</script>", " ", raw, flags=re.IGNORECASE)
+    raw = re.sub(r"<style[\s\S]*?</style>", " ", raw, flags=re.IGNORECASE)
+    text = re.sub(r"<[^>]+>", " ", raw)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def read_html(path: Path) -> str:
+    return strip_html(read_txt(path))
+
+
+def read_pdf(path: Path) -> str:
+    try:
+        from pdfminer.high_level import extract_text  # type: ignore
+
+        return extract_text(str(path)) or ""
+    except Exception:
+        try:
+            import PyPDF2  # type: ignore
+
+            text: list[str] = []
+            with path.open("rb") as fh:
+                reader = PyPDF2.PdfReader(fh)
+                for page in reader.pages:
+                    text.append(page.extract_text() or "")
+            return "\n".join(text)
+        except Exception:
+            return ""
+
+
+def read_docx(path: Path) -> str:
+    try:
+        import docx  # type: ignore
+
+        document = docx.Document(str(path))
+        return "\n".join(para.text for para in document.paragraphs)
+    except Exception:
+        return ""
+
+
+READERS: dict[str, Callable[[Path], str]] = {
+    ".txt": read_txt,
+    ".md": read_md,
+    ".markdown": read_md,
+    ".html": read_html,
+    ".htm": read_html,
+    ".pdf": read_pdf,
+    ".docx": read_docx,
+}
+
+DEFAULT_EXTS = sorted(READERS)
+SEPARATOR = "\n" + ("-" * 80) + "\n"
+
+
+def gather_files(root: Path, extensions: Iterable[str], min_file_bytes: int) -> list[Path]:
+    allowed = {ext.lower() for ext in extensions}
+    files: list[Path] = []
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        if path.suffix.lower() not in allowed:
+            continue
+        try:
+            size = path.stat().st_size
+        except OSError:
+            continue
+        if size < min_file_bytes:
+            continue
+        files.append(path)
+    files.sort()
+    return files
+
+
+def to_text(path: Path) -> str:
+    reader = READERS.get(path.suffix.lower())
+    if reader is None:
+        return ""
+    text = reader(path)
+    if isinstance(text, bytes):
+        text = text.decode("utf-8", errors="ignore")
+    return text or ""
+
+
+def flush_buffer(
+    out_dir: Path,
+    buffer: io.StringIO,
+    records: list[Path],
+    start: int,
+    end: int,
+    binder_index: int,
+    manifest: list[dict[str, str | int]],
+) -> int:
+    content = buffer.getvalue()
+    if not content.strip():
+        return binder_index
+
+    binder_name = f"binder_{binder_index:05d}.txt"
+    binder_path = out_dir / binder_name
+    binder_path.write_text(content, encoding="utf-8")
+    approx_tokens = estimate_tokens(content)
+    size_bytes = binder_path.stat().st_size
+    manifest.append(
+        {
+            "binder_path": str(binder_path),
+            "size_bytes": size_bytes,
+            "approx_tokens": approx_tokens,
+            "source_files": ";".join(str(p) for p in records[start:end]),
+        }
+    )
+    return binder_index + 1
+
+
+def pack(args: Args) -> None:
+    args.out.mkdir(parents=True, exist_ok=True)
+    files = gather_files(args.src, args.extensions, args.min_file_bytes)
+
+    by_parent: dict[Path, list[Path]] = {}
+    for file in files:
+        by_parent.setdefault(file.parent, []).append(file)
+
+    manifest_rows: list[dict[str, str | int]] = []
+    binder_index = 1
+
+    for folder, file_list in sorted(by_parent.items()):
+        buffer = io.StringIO()
+        size_bytes = 0
+        start_idx = 0
+
+        for idx, path in enumerate(file_list):
+            text = to_text(path)
+            if not text.strip():
+                continue
+            if args.src in path.parents:
+                relative_parent = path.parent.relative_to(args.src)
+            else:
+                relative_parent = path.parent
+            header = (
+                f"SOURCE_FILE: {path}\nRELATIVE_TO: {relative_parent}\n\n"
+            )
+            chunk = header + text.strip() + SEPARATOR
+            chunk_bytes = len(chunk.encode("utf-8"))
+            if size_bytes + chunk_bytes > args.binder_bytes and buffer.tell() > 0:
+                binder_index = flush_buffer(
+                    args.out,
+                    buffer,
+                    file_list,
+                    start_idx,
+                    idx,
+                    binder_index,
+                    manifest_rows,
+                )
+                buffer = io.StringIO()
+                size_bytes = 0
+                start_idx = idx
+            buffer.write(chunk)
+            size_bytes += chunk_bytes
+
+        binder_index = flush_buffer(
+            args.out,
+            buffer,
+            file_list,
+            start_idx,
+            len(file_list),
+            binder_index,
+            manifest_rows,
+        )
+
+    manifest_path = args.out / "manifest.csv"
+    with manifest_path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(
+            fh,
+            fieldnames=["binder_path", "size_bytes", "approx_tokens", "source_files"],
+        )
+        writer.writeheader()
+        for row in manifest_rows:
+            writer.writerow(row)
+
+    print(f"Wrote {len(manifest_rows)} binders -> {manifest_path}")
+
+
+def parse_args() -> Args:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--src", required=True, type=Path, help="Root of the corpus")
+    parser.add_argument(
+        "--out", required=True, type=Path, help="Directory for binder files"
+    )
+    parser.add_argument(
+        "--binder-bytes",
+        type=int,
+        default=9_500_000,
+        help="Target bytes per binder (default ≈9.5 MiB)",
+    )
+    parser.add_argument(
+        "--min-file-bytes",
+        type=int,
+        default=256,
+        help="Skip files smaller than this many bytes",
+    )
+    parser.add_argument(
+        "--extensions",
+        nargs="*",
+        default=DEFAULT_EXTS,
+        help="File extensions to include",
+    )
+    ns = parser.parse_args()
+    return Args(
+        src=ns.src.expanduser().resolve(),
+        out=ns.out.expanduser().resolve(),
+        binder_bytes=ns.binder_bytes,
+        min_file_bytes=ns.min_file_bytes,
+        extensions=[ext if ext.startswith(".") else f".{ext}" for ext in ns.extensions],
+    )
+
+
+def main() -> None:
+    args = parse_args()
+    pack(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a gather_tables.py helper to convert ChatGPT UI markdown tables into the CSVs expected by the pipeline
- document how to run the new helper when assembling summarized entities, relationships, and claims

## Testing
- python -m compileall scripts/chatgpt_ui


------
https://chatgpt.com/codex/tasks/task_b_68dadbed10c08331a014a926fe39ae3b