### PR TITLE
Add debug log for community report requests

### DIFF
--- a/graphrag/index/operations/summarize_communities/community_reports_extractor.py
+++ b/graphrag/index/operations/summarize_communities/community_reports_extractor.py
@@ -84,6 +84,18 @@ class CommunityReportsExtractor:
                     MAX_LENGTH_KEY: str(self._max_report_length),
                 },
             )
+            model_name = getattr(getattr(self._model, "config", None), "model", None)
+            log.debug(
+                "Sending community report HTTP request",
+                extra={
+                    "llm_request": {
+                        "model": model_name,
+                        "name": "create_community_report",
+                        "json": True,
+                        "prompt": prompt,
+                    }
+                },
+            )
             response = await self._model.achat(
                 prompt,
                 json=True,  # Leaving this as True to avoid creating new cache entries


### PR DESCRIPTION
## Summary
- add debug logging capturing the model, request name, json flag, and prompt before sending community report LLM calls

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6920ac5d30248331959753929f8f947d)