### PR TITLE
Add response debug logging for community reports

### DIFF
--- a/graphrag/index/operations/summarize_communities/community_reports_extractor.py
+++ b/graphrag/index/operations/summarize_communities/community_reports_extractor.py
@@ -103,6 +103,22 @@ class CommunityReportsExtractor:
                 json_model=CommunityReportResponse,  # A model is required when using json mode
             )
 
+            raw_response_content = getattr(
+                getattr(response, "output", None), "content", None
+            )
+            log.debug(
+                "Received community report HTTP response",
+                extra={
+                    "llm_response": {
+                        "model": model_name,
+                        "name": "create_community_report",
+                        "json": True,
+                        "response": self._model_dump(response),
+                        "raw_content": raw_response_content,
+                    }
+                },
+            )
+
             output = self._parse_llm_response(response)
         except Exception as e:
             log.exception("error generating community report")


### PR DESCRIPTION
## Summary
- add debug logging to record community report LLM responses alongside requests

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6920b4856a0c8331881c201c59c05f3d)