### PR TITLE
Improve community report logging output

### DIFF
--- a/graphrag/index/operations/summarize_communities/community_reports_extractor.py
+++ b/graphrag/index/operations/summarize_communities/community_reports_extractor.py
@@ -107,7 +107,8 @@ class CommunityReportsExtractor:
                 getattr(response, "output", None), "content", None
             )
             log.debug(
-                "Received community report HTTP response",
+                "Received community report HTTP response: %s",
+                self._format_response_for_logging(response, raw_response_content),
                 extra={
                     "llm_response": {
                         "model": model_name,
@@ -156,6 +157,23 @@ class CommunityReportsExtractor:
             return CommunityReportResponse.parse_obj(json_payload)
         except Exception:
             return None
+
+    def _format_response_for_logging(
+        self, response: Any, raw_content: str | None
+    ) -> str:
+        """Return a string representation of the LLM response for logging."""
+
+        if raw_content:
+            return raw_content
+
+        try:
+            response_dict = self._model_dump(response)
+            if response_dict:
+                return json.dumps(response_dict, ensure_ascii=False)
+        except Exception:
+            pass
+
+        return repr(response)
 
     def _format_prompt(self, prompt: str, values: dict[str, str]) -> str:
         """Safely substitute known placeholders in the prompt."""


### PR DESCRIPTION
## Summary
- include LLM response content directly in the community report debug log message
- add a helper to safely format responses for logging

## Testing
- python -m pytest tests/unit/index/operations/summarize_communities/test_community_reports_extractor.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6920ba8eee848331a57d99733efb3e35)