### PR TITLE
Fix level context filtering when generating community reports

### DIFF
--- a/graphrag/index/operations/summarize_communities/text_unit_context/context_builder.py
+++ b/graphrag/index/operations/summarize_communities/text_unit_context/context_builder.py
@@ -140,11 +140,11 @@ def build_level_context(
     )
     valid_context_df = cast(
         "pd.DataFrame",
-        level_context_df[level_context_df[schemas.CONTEXT_EXCEED_FLAG] is False],
+        level_context_df[level_context_df[schemas.CONTEXT_EXCEED_FLAG] == False],
     )
     invalid_context_df = cast(
         "pd.DataFrame",
-        level_context_df[level_context_df[schemas.CONTEXT_EXCEED_FLAG] is True],
+        level_context_df[level_context_df[schemas.CONTEXT_EXCEED_FLAG] == True],
     )
 
     if invalid_context_df.empty:

--- a/tests/unit/index/operations/summarize_communities/test_context_builder.py
+++ b/tests/unit/index/operations/summarize_communities/test_context_builder.py
@@ -1,0 +1,46 @@
+"""Tests for community report context building."""
+
+import pytest
+
+# Some of the context builder's dependencies (e.g., Azure vector store clients) are optional
+# and may not be installed in the test environment. If the Azure SDK is missing, skip the
+# module so the import dependency chain does not fail before the test can run.
+pytest.importorskip("azure")
+
+import pandas as pd
+
+import graphrag.data_model.schemas as schemas
+from graphrag.index.operations.summarize_communities.text_unit_context.context_builder import (
+    build_level_context,
+)
+
+
+def test_build_level_context_filters_valid_records_when_reports_exist():
+    """When reports already exist, valid contexts should be returned."""
+
+    local_context_df = pd.DataFrame(
+        {
+            schemas.COMMUNITY_ID: [1, 2],
+            schemas.COMMUNITY_LEVEL: [0, 0],
+            schemas.CONTEXT_EXCEED_FLAG: [False, False],
+            schemas.ALL_CONTEXT: [[], []],
+            schemas.CONTEXT_STRING: ["context-a", "context-b"],
+            schemas.CONTEXT_SIZE: [10, 12],
+        }
+    )
+
+    report_df = pd.DataFrame({schemas.COMMUNITY_ID: [99], schemas.COMMUNITY_LEVEL: [0]})
+
+    context = build_level_context(
+        report_df=report_df,
+        community_hierarchy_df=pd.DataFrame(
+            columns=[schemas.COMMUNITY_ID, schemas.SUB_COMMUNITY, schemas.COMMUNITY_LEVEL]
+        ),
+        local_context_df=local_context_df,
+        level=0,
+        max_context_tokens=50,
+    )
+
+    pd.testing.assert_frame_equal(
+        context.reset_index(drop=True), local_context_df.reset_index(drop=True)
+    )


### PR DESCRIPTION
## Summary
- fix boolean filtering when choosing valid and oversized community contexts
- add regression coverage for keeping valid level contexts when reports already exist

## Testing
- python -m pytest tests/unit/index/operations/summarize_communities/test_context_builder.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6920c04195c48331940826f74580a1c9)