### PR TITLE
Handle non-standard parsed community report responses

### DIFF
--- a/graphrag/index/operations/summarize_communities/community_reports_extractor.py
+++ b/graphrag/index/operations/summarize_communities/community_reports_extractor.py
@@ -140,7 +140,23 @@ class CommunityReportsExtractor:
 
         parsed = getattr(response, "parsed_response", None)
         if parsed:
-            return parsed
+            if isinstance(parsed, CommunityReportResponse):
+                return parsed
+
+            try:
+                if isinstance(parsed, dict):
+                    if hasattr(CommunityReportResponse, "model_validate"):
+                        return CommunityReportResponse.model_validate(parsed)
+                    return CommunityReportResponse.parse_obj(parsed)
+
+                if isinstance(parsed, str):
+                    loaded = json.loads(parsed)
+                    if hasattr(CommunityReportResponse, "model_validate"):
+                        return CommunityReportResponse.model_validate(loaded)
+                    return CommunityReportResponse.parse_obj(loaded)
+            except Exception:
+                # Fall back to parsing the raw content below when validation fails
+                pass
 
         raw_content = getattr(getattr(response, "output", None), "content", None)
         if not raw_content:


### PR DESCRIPTION
## Summary
- validate parsed community report payloads when providers return dict or string parsed responses
- fall back to raw content parsing when validation fails to keep LLM output available

## Testing
- python -m compileall graphrag/index/operations/summarize_communities/community_reports_extractor.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6920c04195c48331940826f74580a1c9)