### PR TITLE
Handle HuggingFace embedding token limits

### DIFF
--- a/tests_huggingface/test_huggingface_tokens.py
+++ b/tests_huggingface/test_huggingface_tokens.py
@@ -2,10 +2,25 @@ import pytest
 
 pytest.importorskip("tiktoken")
 
-from graphrag.config.models.language_model_config import LanguageModelConfig
 from graphrag.language_model.providers.huggingface.models import (
     HuggingFaceEmbeddingModel,
 )
+
+
+class DummyConfig:
+    def __init__(
+        self,
+        *,
+        api_base: str,
+        model: str = "sentence-transformers/all-MiniLM-L6-v2",
+        encoding_model: str = "cl100k_base",
+        api_key: str | None = None,
+    ) -> None:
+        self.type = "huggingface_embedding"
+        self.model = model
+        self.encoding_model = encoding_model
+        self.api_base = api_base
+        self.api_key = api_key
 
 
 def test_huggingface_model_uses_primary_env_token(monkeypatch):
@@ -13,12 +28,7 @@ def test_huggingface_model_uses_primary_env_token(monkeypatch):
     monkeypatch.setenv("HUGGINGFACEHUB_API_TOKEN", "hf_hub")
     monkeypatch.setenv("HUGGING_FACE_TOKEN_READ_KEY", "hf_legacy")
 
-    config = LanguageModelConfig(
-        type="huggingface_embedding",
-        model="sentence-transformers/all-MiniLM-L6-v2",
-        encoding_model="cl100k_base",
-        api_base="https://example.endpoint",
-    )
+    config = DummyConfig(api_base="https://example.endpoint")
 
     model = HuggingFaceEmbeddingModel(name="hf", config=config)
 
@@ -28,12 +38,7 @@ def test_huggingface_model_uses_primary_env_token(monkeypatch):
 def test_huggingface_model_strips_bearer_prefix(monkeypatch):
     monkeypatch.setenv("HUGGINGFACE_API_TOKEN", "Bearer hf_secret")
 
-    config = LanguageModelConfig(
-        type="huggingface_embedding",
-        model="sentence-transformers/all-MiniLM-L6-v2",
-        encoding_model="cl100k_base",
-        api_base="https://example.endpoint",
-    )
+    config = DummyConfig(api_base="https://example.endpoint")
 
     model = HuggingFaceEmbeddingModel(name="hf", config=config)
 
@@ -44,13 +49,50 @@ def test_huggingface_model_falls_back_to_hub_env_token(monkeypatch):
     monkeypatch.delenv("HUGGINGFACE_API_TOKEN", raising=False)
     monkeypatch.setenv("HUGGINGFACEHUB_API_TOKEN", "hf_hub")
 
-    config = LanguageModelConfig(
-        type="huggingface_embedding",
-        model="sentence-transformers/all-MiniLM-L6-v2",
-        encoding_model="cl100k_base",
-        api_base="https://example.endpoint",
-    )
+    config = DummyConfig(api_base="https://example.endpoint")
 
     model = HuggingFaceEmbeddingModel(name="hf", config=config)
 
     assert model.api_key == "hf_hub"
+
+
+def test_huggingface_model_respects_token_limit(monkeypatch):
+    monkeypatch.setenv("GRAPHRAG_EMBEDDING_TPR", "5")
+    captured_inputs: list[list[str]] = []
+
+    class DummyEncoding:
+        def encode(self, text: str, allowed_special=None, disallowed_special=None):
+            return text.split()
+
+        def decode(self, tokens):
+            return " ".join(tokens)
+
+    import tiktoken
+
+    monkeypatch.setattr(tiktoken, "get_encoding", lambda name: DummyEncoding())
+    monkeypatch.setattr(tiktoken, "encoding_for_model", lambda model: DummyEncoding())
+
+    def fake_post(url, headers, json, timeout):
+        captured_inputs.append(json["inputs"])
+
+        class FakeResponse:
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return {"embeddings": [[float(idx)] for idx, _ in enumerate(json["inputs"])]}
+
+        return FakeResponse()
+
+    monkeypatch.setattr("graphrag.language_model.providers.huggingface.models.requests", type("Requests", (), {"post": staticmethod(fake_post)}))
+
+    config = DummyConfig(api_base="https://example.endpoint")
+
+    model = HuggingFaceEmbeddingModel(name="hf", config=config)
+
+    long_text = "sample text " * 50
+    embeddings = model.embed_batch([long_text])
+
+    assert len(captured_inputs) == 1
+    assert len(captured_inputs[0]) > 1
+    assert embeddings == [[1.0]]


### PR DESCRIPTION
## Summary
- add support for respecting GRAPHRAG_EMBEDDING_TPR by splitting HuggingFace embedding inputs to the configured token limit and recombining results
- ensure embedding requests average chunk embeddings to return one vector per original input
- extend HuggingFace provider tests with token limit coverage using dependency stubs

## Testing
- pytest tests_huggingface/test_huggingface_tokens.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6921ea320b4c83319088b790e27da491)