### PR TITLE
Default encoding name when unset

### DIFF
--- a/graphrag/index/text_splitting/text_splitting.py
+++ b/graphrag/index/text_splitting/text_splitting.py
@@ -96,6 +96,8 @@ class TokenTextSplitter(TextSplitter):
     ):
         """Init method definition."""
         super().__init__(**kwargs)
+        if not encoding_name:
+            encoding_name = defs.ENCODING_MODEL
         if model_name is not None:
             try:
                 enc = tiktoken.encoding_for_model(model_name)


### PR DESCRIPTION
## Summary
- fallback to the default encoding when the provided encoding name is empty in TokenTextSplitter
- avoid tiktoken errors when configuration leaves the encoding value blank

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6921ee34fe1883319a8e3caaeb850ef5)